### PR TITLE
feat: add automatic binary installation via GitHub Releases

### DIFF
--- a/.claude-plugin/hooks.json
+++ b/.claude-plugin/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/install.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "pyright-lsp-proxy",
+  "version": "0.1.0",
+  "description": "Pyright LSP proxy for monorepo with automatic .venv switching",
+  "author": {
+    "name": "K-dash"
+  },
+  "homepage": "https://github.com/K-dash/pyright-lsp-proxy",
+  "repository": "https://github.com/K-dash/pyright-lsp-proxy",
+  "license": "MIT",
+  "keywords": ["lsp", "pyright", "proxy", "rust", "monorepo", "python"],
+  "hooks": "./hooks.json",
+  "lspServers": {
+    "pyright-lsp-proxy": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/pyright-lsp-proxy",
+      "args": [],
+      "extensionToLanguage": {
+        ".py": "python",
+        ".pyi": "python"
+      }
+    }
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            binary_name: pyright-lsp-proxy-macos-arm64
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary_name: pyright-lsp-proxy-linux-x86_64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Rename binary
+        run: |
+          cp target/${{ matrix.target }}/release/pyright-lsp-proxy ${{ matrix.binary_name }}
+          chmod +x ${{ matrix.binary_name }}
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ matrix.binary_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ target
 
 .DS_Store
 tmp/
+
+# Plugin binary directory (downloaded by install.sh)
+bin/

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+
+# Claude Plugin Root（環境変数から取得）
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+BIN_DIR="${PLUGIN_ROOT}/bin"
+BINARY_PATH="${BIN_DIR}/pyright-lsp-proxy"
+
+# バイナリが既に存在すれば何もしない
+if [ -f "${BINARY_PATH}" ]; then
+  echo "[pyright-lsp-proxy] Binary already installed at ${BINARY_PATH}"
+  exit 0
+fi
+
+echo "[pyright-lsp-proxy] Installing binary..."
+
+# bin ディレクトリを作成
+mkdir -p "${BIN_DIR}"
+
+# OS/アーキテクチャの検出
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$OS" in
+  Darwin)
+    if [ "$ARCH" = "arm64" ]; then
+      BINARY_NAME="pyright-lsp-proxy-macos-arm64"
+    else
+      echo "[pyright-lsp-proxy] ERROR: Intel macOS is not supported" >&2
+      echo "[pyright-lsp-proxy] Only Apple Silicon (arm64) is supported on macOS" >&2
+      exit 1
+    fi
+    ;;
+  Linux)
+    BINARY_NAME="pyright-lsp-proxy-linux-x86_64"
+    ;;
+  *)
+    echo "[pyright-lsp-proxy] ERROR: Unsupported platform: $OS" >&2
+    echo "[pyright-lsp-proxy] Supported platforms: macOS (arm64), Linux (x86_64)" >&2
+    exit 1
+    ;;
+esac
+
+echo "[pyright-lsp-proxy] Detected platform: $OS $ARCH"
+echo "[pyright-lsp-proxy] Binary to download: $BINARY_NAME"
+
+# GitHub Release から最新バージョンの URL を取得
+REPO="K-dash/pyright-lsp-proxy"
+LATEST_RELEASE=$(curl -s "https://api.github.com/repos/${REPO}/releases/latest")
+DOWNLOAD_URL=$(echo "$LATEST_RELEASE" | grep "browser_download_url.*${BINARY_NAME}" | cut -d '"' -f 4)
+
+if [ -z "$DOWNLOAD_URL" ]; then
+  echo "[pyright-lsp-proxy] ERROR: Failed to find binary for ${BINARY_NAME}" >&2
+  echo "[pyright-lsp-proxy] Please check https://github.com/${REPO}/releases for available binaries" >&2
+  exit 1
+fi
+
+echo "[pyright-lsp-proxy] Downloading from: $DOWNLOAD_URL"
+
+# ダウンロードして実行権限を付与
+if ! curl -L -o "${BINARY_PATH}" "$DOWNLOAD_URL"; then
+  echo "[pyright-lsp-proxy] ERROR: Failed to download binary" >&2
+  exit 1
+fi
+
+chmod +x "${BINARY_PATH}"
+
+echo "[pyright-lsp-proxy] Successfully installed to ${BINARY_PATH}"
+echo "[pyright-lsp-proxy] Version:"
+"${BINARY_PATH}" --version || true


### PR DESCRIPTION
Implement auto-install mechanism following Claude Code plugin best practices. Users no longer need Rust installed - binaries are automatically downloaded from GitHub Releases on first use.

Added files:
- .github/workflows/release.yml: Multi-platform CI build (macOS arm64, Linux x86_64)
- .claude-plugin/plugin.json: Plugin metadata with LSP server config
- .claude-plugin/hooks.json: SessionStart hook to trigger install.sh
- install.sh: Auto-download script with OS/arch detection

Features:
- Detects platform (macOS arm64 or Linux x86_64)
- Downloads appropriate binary from latest GitHub Release
- Installs to ${CLAUDE_PLUGIN_ROOT}/bin/pyright-lsp-proxy
- Skips download if binary already exists
- Intel macOS explicitly unsupported (Apple Silicon only)

User experience:
1. /plugin marketplace add K-dash/pyright-lsp-proxy
2. /plugin install pyright-lsp-proxy@pyright-lsp-proxy
3. Binary auto-downloads on first session start
4. Ready to use (no Rust required)

This enables one-command installation for end users without requiring local compilation.