### PR TITLE
feat: add CI workflow and update release workflow for Rust projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: Makefile CI (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - ubuntu-24.04-arm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run Makefile CI
+        run: make ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/src/backend_state.rs
+++ b/src/backend_state.rs
@@ -1,15 +1,15 @@
 use crate::backend::PyrightBackend;
 use std::path::PathBuf;
 
-/// backend の状態
+/// Backend state
 pub enum BackendState {
-    /// backend が動作中
+    /// Backend is running
     Running {
         backend: Box<PyrightBackend>,
         active_venv: PathBuf,
         session: u64,
     },
-    /// backend が無効（venv が見つからない）
+    /// Backend is disabled (venv not found)
     Disabled {
         reason: String,
         last_file: Option<PathBuf>,
@@ -17,12 +17,12 @@ pub enum BackendState {
 }
 
 impl BackendState {
-    /// backend が Disabled 状態かどうか
+    /// Check if backend is in Disabled state
     pub fn is_disabled(&self) -> bool {
         matches!(self, BackendState::Disabled { .. })
     }
 
-    /// active_venv を取得（Running 時のみ）
+    /// Get active_venv (only when Running)
     pub fn active_venv(&self) -> Option<&PathBuf> {
         match self {
             BackendState::Running { active_venv, .. } => Some(active_venv),
@@ -30,7 +30,7 @@ impl BackendState {
         }
     }
 
-    /// Disabled 状態の詳細を取得
+    /// Get details of Disabled state
     pub fn disabled_info(&self) -> Option<(&str, Option<&PathBuf>)> {
         match self {
             BackendState::Disabled { reason, last_file } => {
@@ -40,7 +40,7 @@ impl BackendState {
         }
     }
 
-    /// Running 時の session を取得
+    /// Get session when Running
     pub fn session(&self) -> Option<u64> {
         match self {
             BackendState::Running { session, .. } => Some(*session),

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,9 +26,9 @@ struct Args {
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    // ログ初期化（デフォルトは stderr、--log-file でファイル出力を追加）
+    // Initialize logging (default: stderr, --log-file adds file output)
     if let Some(log_path) = &args.log_file {
-        // ファイル出力が指定された場合：stderr + ファイル
+        // File output specified: stderr + file
         let file_appender = RollingFileAppender::new(
             Rotation::NEVER,
             log_path.parent().unwrap_or(std::path::Path::new(".")),
@@ -63,7 +63,7 @@ async fn main() -> anyhow::Result<()> {
             "Starting pyright-lsp-proxy (logging to stderr and file)"
         );
     } else {
-        // デフォルト：stderr のみ
+        // Default: stderr only
         tracing_subscriber::registry()
             .with(
                 fmt::layer()
@@ -81,7 +81,7 @@ async fn main() -> anyhow::Result<()> {
         tracing::info!("Starting pyright-lsp-proxy (logging to stderr only)");
     }
 
-    // プロキシを起動
+    // Start proxy
     let mut proxy = LspProxy::new();
     proxy.run().await?;
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-/// JSON-RPC メッセージの共通構造（パススルー用）
+/// Common structure for JSON-RPC messages (for passthrough)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RpcMessage {
     pub jsonrpc: String,
@@ -33,22 +33,22 @@ pub struct RpcError {
 }
 
 impl RpcMessage {
-    /// リクエストかどうか
+    /// Check if this is a request
     pub fn is_request(&self) -> bool {
         self.id.is_some() && self.method.is_some()
     }
 
-    /// 通知かどうか
+    /// Check if this is a notification
     pub fn is_notification(&self) -> bool {
         self.id.is_none() && self.method.is_some()
     }
 
-    /// レスポンスかどうか
+    /// Check if this is a response
     pub fn is_response(&self) -> bool {
         self.id.is_some() && self.method.is_none()
     }
 
-    /// メソッド名を取得
+    /// Get method name
     pub fn method_name(&self) -> Option<&str> {
         self.method.as_deref()
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,14 +3,14 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use url::Url;
 
-/// 未解決リクエストの情報
+/// Information about pending requests
 #[derive(Debug, Clone)]
 pub struct PendingRequest {
-    /// このリクエストが送られた backend の session
+    /// Backend session this request was sent to
     pub backend_session: u64,
 }
 
-/// 開いているドキュメント（Phase 3b-2）
+/// Open document
 #[derive(Debug, Clone)]
 pub struct OpenDocument {
     pub language_id: String,
@@ -19,21 +19,21 @@ pub struct OpenDocument {
     pub venv: Option<PathBuf>,
 }
 
-/// プロキシが保持する状態（Phase 3b-2: 複数ドキュメント復元版）
+/// State held by proxy
 pub struct ProxyState {
-    /// git toplevel（探索上限、初回取得でキャッシュ）
+    /// Git toplevel (search boundary, cached on first retrieval)
     pub git_toplevel: Option<PathBuf>,
 
-    /// Claude Code からの initialize メッセージ（backend 初期化で流用）
+    /// Initialize message from Claude Code (reused for backend initialization)
     pub client_initialize: Option<RpcMessage>,
 
-    /// 開いているドキュメント（Phase 3b-2）
+    /// Open documents
     pub open_documents: HashMap<Url, OpenDocument>,
 
-    /// backend 再起動の世代（ログと競合回避用）
+    /// Backend restart generation (for logging and conflict avoidance)
     pub backend_session: u64,
 
-    /// 未解決リクエスト（世代付き）
+    /// Pending requests (with generation)
     pub pending_requests: HashMap<RpcId, PendingRequest>,
 }
 


### PR DESCRIPTION
- Introduced a new CI workflow in `.github/workflows/ci.yml` to automate testing across multiple OS environments (Ubuntu, macOS, and ARM).
- Updated the release workflow to use `actions/checkout@v5` for improved functionality.
- Enhanced caching and setup steps for Rust projects in the CI process.

This update streamlines the development process and ensures consistent testing across platforms.