### PR TITLE
feat: add TTL-based auto-eviction for idle backends

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -2,6 +2,7 @@ use crate::backend_pool::BackendPool;
 use crate::message::{RpcId, RpcMessage};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::time::Duration;
 use url::Url;
 
 /// Information about pending requests
@@ -60,7 +61,7 @@ pub struct ProxyState {
 }
 
 impl ProxyState {
-    pub fn new(max_backends: usize) -> Self {
+    pub fn new(max_backends: usize, backend_ttl: Option<Duration>) -> Self {
         Self {
             git_toplevel: None,
             client_initialize: None,
@@ -68,7 +69,7 @@ impl ProxyState {
             pending_requests: HashMap::new(),
             pending_backend_requests: HashMap::new(),
             next_proxy_request_id: -1, // Use negative IDs to avoid collision with client IDs
-            pool: BackendPool::new(max_backends),
+            pool: BackendPool::new(max_backends, backend_ttl),
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #5

- Add configurable `--backend-ttl` (default: 1800s / 30min, env: `PYRIGHT_LSP_PROXY_BACKEND_TTL`) that automatically shuts down idle backends to reclaim memory (~200-500MB per pyright process)
- A 60-second interval sweep evicts backends whose `last_used` exceeds the TTL, skipping those with pending client→backend or backend→client requests
- Raise `max_backends` default from 4 → 8 with `>= 1` validation to better support parallel AI coding (multiple worktrees)
- Special value `--backend-ttl 0` disables TTL eviction entirely (LRU-only mode)

## Changes

| File | Change |
|------|--------|
| `src/backend_pool.rs` | Add `backend_ttl` field, `expired_venvs()` method |
| `src/state.rs` | Thread `backend_ttl` through `ProxyState::new()` |
| `src/proxy.rs` | Add TTL interval timer (3rd `select!` arm), `evict_expired_backends()` |
| `src/main.rs` | Add `--backend-ttl` CLI arg, update defaults, add validation |

## Design decisions

- **60s interval sweep** over `sleep_until` — simpler, no re-calculation needed on every `last_used` update, trivially cheap for 1-8 backends
- **`MissedTickBehavior::Delay`** — prevents burst ticks after sweep delays
- **Both `pending_requests` and `pending_backend_requests`** checked before eviction — prevents evicting backends mid-request (including `workspace/configuration` from backend)
- **Responsibility split** — `expired_venvs()` does TTL/last_used filtering only; `LspProxy` handles pending-request checks

## Test plan

- [x] `make ci` passes (fmt, clippy, test)
- [ ] Manual test: start with `PYRIGHT_LSP_PROXY_BACKEND_TTL=30`, open files from 2 venvs, wait 30s+ → verify TTL eviction in logs
- [ ] Manual test: `--backend-ttl 0` → verify no TTL eviction occurs
- [ ] Manual test: `--max-backends 0` → verify CLI rejects with validation error