### PR TITLE
refactor: generalize backend to support pyright, ty, and pyrefly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,8 @@ Before committing, verify:
 - When user says "commit", first check current branch and create feature branch if on main
 - When user-facing behavior changes, proactively update README.md before committing
 - **All code comments, commit messages, PR titles, PR descriptions, and review comments MUST be written in English**
+- **No implicit fallbacks** — Never add silent fallback logic that masks errors. Let it fail loudly so unintended behavior is caught early. An explicit error is always better than a silent wrong result.
+- **No backward compatibility** — Do not preserve backward compatibility unless the user explicitly requests it. Breaking changes are the default; do not add compatibility shims, re-exports, or deprecation wrappers.
 
 ### Plan-First Rule
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ pub enum ProxyError {
 
 #[derive(Error, Debug)]
 pub enum BackendError {
-    #[error("Failed to spawn pyright: {0}")]
+    #[error("Failed to spawn backend: {0}")]
     SpawnFailed(#[from] std::io::Error),
 
     #[error("Initialize timeout after {0}s")]

--- a/src/proxy/initialization.rs
+++ b/src/proxy/initialization.rs
@@ -1,4 +1,4 @@
-use crate::backend::PyrightBackend;
+use crate::backend::LspBackend;
 use crate::backend_pool::{spawn_reader_task, BackendInstance};
 use crate::error::ProxyError;
 use crate::framing::LspFrameWriter;
@@ -11,7 +11,7 @@ impl super::LspProxy {
     /// Returns the initialize response to forward to the client.
     pub(crate) async fn complete_backend_initialization(
         &self,
-        backend: &mut PyrightBackend,
+        backend: &mut LspBackend,
         venv: &Path,
         _client_writer: &mut LspFrameWriter<tokio::io::Stdout>,
     ) -> Result<RpcMessage, ProxyError> {
@@ -124,7 +124,7 @@ impl super::LspProxy {
         );
 
         // 1. Spawn
-        let mut backend = PyrightBackend::spawn(Some(venv)).await?;
+        let mut backend = LspBackend::spawn(self.state.backend_kind, Some(venv)).await?;
 
         // 2. Initialize handshake (direct read/write before split)
         let init_params = self
@@ -229,7 +229,7 @@ impl super::LspProxy {
     /// Restore documents belonging to a venv to a backend
     pub(crate) async fn restore_documents_to_backend(
         &self,
-        backend: &mut PyrightBackend,
+        backend: &mut LspBackend,
         venv: &Path,
         session: u64,
         _client_writer: &mut LspFrameWriter<tokio::io::Stdout>,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,3 +1,4 @@
+use crate::backend::BackendKind;
 use crate::backend_pool::BackendPool;
 use crate::message::{RpcId, RpcMessage};
 use std::collections::HashMap;
@@ -37,6 +38,9 @@ pub struct OpenDocument {
 
 /// State held by proxy
 pub struct ProxyState {
+    /// Which LSP backend to use
+    pub backend_kind: BackendKind,
+
     /// Git toplevel (search boundary, cached on first retrieval)
     pub git_toplevel: Option<PathBuf>,
 
@@ -61,8 +65,13 @@ pub struct ProxyState {
 }
 
 impl ProxyState {
-    pub fn new(max_backends: usize, backend_ttl: Option<Duration>) -> Self {
+    pub fn new(
+        backend_kind: BackendKind,
+        max_backends: usize,
+        backend_ttl: Option<Duration>,
+    ) -> Self {
         Self {
+            backend_kind,
             git_toplevel: None,
             client_initialize: None,
             open_documents: HashMap::new(),


### PR DESCRIPTION
## Summary

- Replace hardcoded `pyright-langserver` coupling with a configurable `BackendKind` enum supporting multiple Python type-checker backends (pyright, ty, pyrefly)
- Rename `PyrightBackend` → `LspBackend` and parameterize `spawn()` with backend kind
- Add `--backend` CLI argument (`pyright` | `ty` | `pyrefly`, default: `pyright`) with strict validation via `clap::ValueEnum` — invalid values are rejected at startup
- Extract `apply_env()` method on `BackendKind` for future backend-specific environment variable setup
- Genericize error messages from `pyright-lsp-proxy:` to `lsp-proxy:`

This is Phase 1 of the multi-backend refactoring. Phase 2 (project rename to `typemux-cc`) will follow in a separate PR.

## Backend support

| Backend | Command | Args | Status |
|---------|---------|------|--------|
| pyright | `pyright-langserver` | `--stdio` | Default, production |
| ty | `ty` | `server` | New, needs verification |
| pyrefly | `pyrefly` | `lsp` | New, needs verification |

## Files changed (7)

- `src/backend.rs` — Add `BackendKind` enum, rename struct, parameterize spawn, add tests
- `src/state.rs` — Add `backend_kind` field to `ProxyState`
- `src/proxy/mod.rs` — Wire `BackendKind` through proxy constructor and spawn
- `src/proxy/initialization.rs` — Update types from `PyrightBackend` to `LspBackend`
- `src/proxy/client_dispatch.rs` — Update types, genericize error messages
- `src/error.rs` — Genericize error message
- `src/main.rs` — Add `--backend` CLI argument

## Test plan

- [x] `make all` passes (fmt + clippy + test)
- [x] 3 new unit tests for `BackendKind` (command/args, display_name, Display trait)
- [x] `--backend pyright` (default) behavior identical to before
- [ ] `--backend ty` spawns `ty server` (manual verification with ty installed)
- [ ] `--backend pyrefly` spawns `pyrefly lsp` (manual verification with pyrefly installed)