### PR TITLE
chore: update repository URLs to K-dash/typemux-cc

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,8 +10,8 @@
       "source": "./",
       "description": "Python type-checker LSP multiplexer for Claude Code (pyright, ty, pyrefly)",
       "version": "0.1.13",
-      "homepage": "https://github.com/K-dash/pyright-lsp-proxy",
-      "repository": "https://github.com/K-dash/pyright-lsp-proxy",
+      "homepage": "https://github.com/K-dash/typemux-cc",
+      "repository": "https://github.com/K-dash/typemux-cc",
       "strict": false
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,8 +5,8 @@
   "author": {
     "name": "K-dash"
   },
-  "homepage": "https://github.com/K-dash/pyright-lsp-proxy",
-  "repository": "https://github.com/K-dash/pyright-lsp-proxy",
+  "homepage": "https://github.com/K-dash/typemux-cc",
+  "repository": "https://github.com/K-dash/typemux-cc",
   "license": "MIT",
   "keywords": ["lsp", "pyright", "ty", "pyrefly", "proxy", "rust", "monorepo", "python"],
   "hooks": "./hooks.json",

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -62,4 +62,4 @@ git push origin v<NEW_VERSION>
 ### Step 5: Verify
 
 Inform the user the CI pipeline will build and create the GitHub Release. Link to:
-`https://github.com/K-dash/pyright-lsp-proxy/actions`
+`https://github.com/K-dash/typemux-cc/actions`

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 **Python type-checker LSP multiplexer for Claude Code — pyright, ty, pyrefly**
 
 <div align="center">
-  <a href="https://github.com/K-dash/pyright-lsp-proxy/graphs/commit-activity"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/K-dash/pyright-lsp-proxy"/></a>
-  <a href="https://github.com/K-dash/pyright-lsp-proxy/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/LICENSE-MIT-green"/></a>
+  <a href="https://github.com/K-dash/typemux-cc/graphs/commit-activity"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/K-dash/typemux-cc"/></a>
+  <a href="https://github.com/K-dash/typemux-cc/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/LICENSE-MIT-green"/></a>
   <a href="https://www.rust-lang.org/"><img alt="Rust" src="https://img.shields.io/badge/rust-1.75+-orange.svg"/></a>
 </div>
 
@@ -107,7 +107,7 @@ pip install pyrefly
 
 ```bash
 # 1. Add marketplace
-/plugin marketplace add K-dash/pyright-lsp-proxy
+/plugin marketplace add K-dash/typemux-cc
 
 # 2. Install plugin
 /plugin install typemux-cc@typemux-cc-marketplace
@@ -140,11 +140,11 @@ After installation, verify in `~/.claude/settings.json`:
 ### Method B: Local Build (For Developers)
 
 ```bash
-git clone https://github.com/K-dash/pyright-lsp-proxy.git
-cd pyright-lsp-proxy
+git clone https://github.com/K-dash/typemux-cc.git
+cd typemux-cc
 cargo build --release
 
-/plugin marketplace add /path/to/pyright-lsp-proxy
+/plugin marketplace add /path/to/typemux-cc
 /plugin install typemux-cc@typemux-cc-marketplace
 # Restart Claude Code (initial installation only)
 ```

--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ echo "[typemux-cc] Detected platform: $OS $ARCH"
 echo "[typemux-cc] Binary to download: $BINARY_NAME"
 
 # Get latest version URL from GitHub Release
-REPO="K-dash/pyright-lsp-proxy"
+REPO="K-dash/typemux-cc"
 LATEST_RELEASE=$(curl -s "https://api.github.com/repos/${REPO}/releases/latest")
 DOWNLOAD_URL=$(echo "$LATEST_RELEASE" | grep "browser_download_url.*${BINARY_NAME}" | cut -d '"' -f 4)
 


### PR DESCRIPTION
## Summary

- Replace all remaining `K-dash/pyright-lsp-proxy` repository references with `K-dash/typemux-cc` after the GitHub repository rename
- Updates: plugin.json, marketplace.json, install.sh, README.md, publish skill

## Test plan

- [x] `make all` passes (21 tests)
- [x] `grep -r pyright-lsp-proxy` returns zero matches