### PR TITLE
fix: send window/showMessage error on backend creation failure

### DIFF
--- a/src/proxy/document.rs
+++ b/src/proxy/document.rs
@@ -111,6 +111,8 @@ impl super::LspProxy {
                         error = ?e,
                         "Failed to create backend for didOpen"
                     );
+                    self.notify_backend_error(venv_path, &e, client_writer)
+                        .await;
                     return Ok(());
                 }
             }


### PR DESCRIPTION
## Summary

- When `create_backend_instance()` fails during `didOpen`, send a `window/showMessage` (Error) notification to the client with the venv path and error details
- Previously, the error was only logged server-side and the client received no indication of failure — contradicting the "no silent failures" design principle

## Changes

- **`src/proxy/diagnostics.rs`**: Add `notify_backend_error()` method that sends `window/showMessage` with `MessageType.Error` (type: 1)
- **`src/proxy/document.rs`**: Call `notify_backend_error()` in the `Err` branch of `create_backend_instance()` during `didOpen`

## Test plan

- [x] `make all` passes (fmt + clippy + tests)
- [ ] Manual: with pyright uninstalled, open a Python file → verify error message appears in client
- [ ] Manual: with a broken `.venv`, open a Python file → verify error message shows venv path and cause

Closes #16