### PR TITLE
fix: restrict best-effort fallback routing for requests without resolved venv

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ For small, well-scoped changes (single-file fixes, typo corrections, simple bug 
 - Rust 2021 edition
 - Use `cargo fmt` for formatting
 - All clippy warnings treated as errors (`-D warnings`)
+- **Prefer early returns over deep nesting** — Use guard clauses (`let x = match ... { Err => return }`) to keep the happy path flat. Avoid nesting `match`/`if let` more than 2 levels deep.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Closes #15

- Extend venv resolution to **all URI-bearing requests** on cache miss (not just `VENV_CHECK_METHODS`), eliminating the cache-miss → arbitrary-backend fallback path
- For **URI-less requests** (`workspace/symbol`, `workspace/executeCommand`): forward to sole backend when pool has 1 entry, return explicit error when multiple backends are active
- Extract `forward_to_first_backend` helper to reduce code duplication
- Non-file URIs (`untitled:`, `vscode-notebook-cell:`, etc.) now return explicit errors instead of silently falling through

## Context

When a request had no resolved venv but the backend pool was not empty, the proxy forwarded to an arbitrary backend unconditionally. In multi-venv setups, this risked returning results from the wrong venv — violating the "a silently lying LSP is the worst" design philosophy.

### Approach: Two-pronged fix

| Condition | Before | After |
|---|---|---|
| URI-bearing request, cache miss | Fall through to arbitrary backend | Full venv resolution via `ensure_backend_in_pool` |
| URI-bearing request, non-file URI | Silent fall-through | Explicit error |
| URI-less request, 1 backend | Forward to arbitrary backend | Forward to sole backend (same behavior, explicit intent) |
| URI-less request, 2+ backends | Forward to arbitrary backend | Explicit error |

## Test plan

- [x] `make all` (fmt + clippy + test) passes
- [ ] Single-venv: all methods including `workspace/symbol` work normally
- [ ] Multi-venv: URI-bearing methods resolve correctly; `workspace/symbol` returns error with 2+ backends
- [ ] Log inspection: `RUST_LOG=debug` shows new tracing messages for rejected requests