### PR TITLE
refactor: consolidate duplicated BackendInstance and eviction logic

### DIFF
--- a/src/backend_pool.rs
+++ b/src/backend_pool.rs
@@ -1,4 +1,4 @@
-use crate::backend::shutdown_fire_and_forget;
+use crate::backend::{shutdown_fire_and_forget, BackendParts};
 use crate::error::BackendError;
 use crate::framing::{LspFrameReader, LspFrameWriter};
 use crate::message::{RpcId, RpcMessage};
@@ -55,6 +55,34 @@ pub struct BackendInstance {
 }
 
 impl BackendInstance {
+    /// Create a `BackendInstance` from a split backend, spawning the reader task
+    /// and computing the warmup state. Does NOT insert into the pool.
+    pub fn from_parts(
+        parts: BackendParts,
+        venv_path: PathBuf,
+        session: u64,
+        msg_sender: mpsc::Sender<BackendMessage>,
+    ) -> Self {
+        let reader_task = spawn_reader_task(parts.reader, msg_sender, venv_path.clone(), session);
+        let timeout = warmup_timeout();
+        Self {
+            writer: parts.writer,
+            child: parts.child,
+            venv_path,
+            session,
+            last_used: Instant::now(),
+            reader_task,
+            next_id: parts.next_id,
+            warmup_state: if timeout.is_zero() {
+                WarmupState::Ready
+            } else {
+                WarmupState::Warming
+            },
+            warmup_deadline: Instant::now() + timeout,
+            warmup_queue: Vec::new(),
+        }
+    }
+
     /// Get next request ID for this backend (used for shutdown messages)
     #[allow(dead_code)]
     pub fn next_id(&mut self) -> u64 {

--- a/src/proxy/client_dispatch.rs
+++ b/src/proxy/client_dispatch.rs
@@ -1,7 +1,5 @@
 use crate::backend::LspBackend;
-use crate::backend_pool::{
-    shutdown_backend_instance, spawn_reader_task, warmup_timeout, BackendInstance, WarmupState,
-};
+use crate::backend_pool::{shutdown_backend_instance, BackendInstance};
 use crate::error::ProxyError;
 use crate::framing::LspFrameWriter;
 use crate::message::{RpcId, RpcMessage};
@@ -41,25 +39,7 @@ impl super::LspProxy {
                     let session = self.state.pool.next_session_id();
                     let parts = backend.into_split();
                     let tx = self.state.pool.msg_sender();
-                    let reader_task = spawn_reader_task(parts.reader, tx, venv.clone(), session);
-
-                    let timeout = warmup_timeout();
-                    let instance = BackendInstance {
-                        writer: parts.writer,
-                        child: parts.child,
-                        venv_path: venv.clone(),
-                        session,
-                        last_used: Instant::now(),
-                        reader_task,
-                        next_id: parts.next_id,
-                        warmup_state: if timeout.is_zero() {
-                            WarmupState::Ready
-                        } else {
-                            WarmupState::Warming
-                        },
-                        warmup_deadline: Instant::now() + timeout,
-                        warmup_queue: Vec::new(),
-                    };
+                    let instance = BackendInstance::from_parts(parts, venv.clone(), session, tx);
                     self.state.pool.insert(venv, instance);
 
                     // Send initialize response to client

--- a/src/proxy/document.rs
+++ b/src/proxy/document.rs
@@ -93,24 +93,13 @@ impl super::LspProxy {
         };
 
         if !self.state.pool.contains(venv_path) {
-            // Need to create backend
-            if self.state.pool.is_full() {
-                self.evict_lru_backend(client_writer).await?;
-            }
-
-            match self.create_backend_instance(venv_path, client_writer).await {
-                Ok(instance) => {
-                    self.state.pool.insert(venv_path.clone(), instance);
-                    // didOpen was already restored during create_backend_instance
-                    // (restore_documents_to_backend sends didOpen for matching docs)
-                    return Ok(());
-                }
+            match self
+                .ensure_backend_in_pool(&url, &file_path, client_writer)
+                .await
+            {
+                Ok(Some(_)) => return Ok(()), // didOpen restored during backend creation
+                Ok(None) => return Ok(()),
                 Err(e) => {
-                    tracing::error!(
-                        venv = %venv_path.display(),
-                        error = ?e,
-                        "Failed to create backend for didOpen"
-                    );
                     self.notify_backend_error(venv_path, &e, client_writer)
                         .await;
                     return Ok(());

--- a/src/proxy/initialization.rs
+++ b/src/proxy/initialization.rs
@@ -1,11 +1,10 @@
 use crate::backend::LspBackend;
-use crate::backend_pool::{spawn_reader_task, warmup_timeout, BackendInstance, WarmupState};
+use crate::backend_pool::BackendInstance;
 use crate::error::ProxyError;
 use crate::framing::LspFrameWriter;
 use crate::message::{RpcId, RpcMessage};
 use serde_json::Value;
 use std::path::Path;
-use tokio::time::Instant;
 
 /// Perform the LSP initialize handshake with a backend:
 /// 1. Send `initialize` request with the given params
@@ -154,25 +153,12 @@ impl super::LspProxy {
         // 4. Split and create instance
         let parts = backend.into_split();
         let tx = self.state.pool.msg_sender();
-        let reader_task = spawn_reader_task(parts.reader, tx, venv.to_path_buf(), session);
-
-        let timeout = warmup_timeout();
-        Ok(BackendInstance {
-            writer: parts.writer,
-            child: parts.child,
-            venv_path: venv.to_path_buf(),
+        Ok(BackendInstance::from_parts(
+            parts,
+            venv.to_path_buf(),
             session,
-            last_used: Instant::now(),
-            reader_task,
-            next_id: parts.next_id,
-            warmup_state: if timeout.is_zero() {
-                WarmupState::Ready
-            } else {
-                WarmupState::Warming
-            },
-            warmup_deadline: Instant::now() + timeout,
-            warmup_queue: Vec::new(),
-        })
+            tx,
+        ))
     }
 
     /// Restore documents belonging to a venv to a backend

--- a/src/proxy/pool_management.rs
+++ b/src/proxy/pool_management.rs
@@ -1,4 +1,4 @@
-use crate::backend_pool::shutdown_backend_instance;
+use crate::backend_pool::{shutdown_backend_instance, BackendInstance};
 use crate::error::ProxyError;
 use crate::framing::LspFrameWriter;
 use crate::message::{RpcId, RpcMessage};
@@ -68,24 +68,14 @@ impl super::LspProxy {
 
             if let Some(instance) = self.state.pool.remove(&venv_to_evict) {
                 let evict_session = instance.session;
-
-                // Cancel pending requests for this backend
-                self.cancel_pending_requests_for_backend(
-                    client_writer,
+                self.cleanup_evicted_backend(
+                    instance,
                     &venv_to_evict,
                     evict_session,
+                    client_writer,
+                    true,
                 )
                 .await?;
-
-                // Clean up pending_backend_requests for this backend
-                self.clean_pending_backend_requests(&venv_to_evict, evict_session);
-
-                // Clear diagnostics for documents under this venv
-                self.clear_diagnostics_for_venv(&venv_to_evict, client_writer)
-                    .await;
-
-                // Shutdown
-                shutdown_backend_instance(instance);
             }
         }
 
@@ -149,16 +139,14 @@ impl super::LspProxy {
 
             if let Some(instance) = self.state.pool.remove(&venv_path) {
                 let evict_session = instance.session;
-
-                self.cancel_pending_requests_for_backend(client_writer, &venv_path, evict_session)
-                    .await?;
-
-                self.clean_pending_backend_requests(&venv_path, evict_session);
-
-                self.clear_diagnostics_for_venv(&venv_path, client_writer)
-                    .await;
-
-                shutdown_backend_instance(instance);
+                self.cleanup_evicted_backend(
+                    instance,
+                    &venv_path,
+                    evict_session,
+                    client_writer,
+                    true,
+                )
+                .await?;
             }
         }
 
@@ -195,17 +183,10 @@ impl super::LspProxy {
         );
 
         if let Some(instance) = self.state.pool.remove(venv_path) {
-            // Cancel pending requests
-            self.cancel_pending_requests_for_backend(client_writer, venv_path, session)
+            // do_shutdown=false: process is already dead, just abort reader + clean up
+            self.cleanup_evicted_backend(instance, venv_path, session, client_writer, false)
                 .await?;
 
-            // Clean up pending_backend_requests
-            self.clean_pending_backend_requests(venv_path, session);
-
-            // Abort reader task (it already exited with error, but be safe)
-            instance.reader_task.abort();
-
-            // Don't attempt graceful shutdown — process is already dead
             tracing::info!(
                 venv = %venv_path.display(),
                 session = session,
@@ -213,6 +194,30 @@ impl super::LspProxy {
             );
         }
 
+        Ok(())
+    }
+
+    /// Clean up after removing a backend instance from the pool.
+    /// Cancels pending requests, clears diagnostics, and shuts down the process.
+    /// Set `do_shutdown` to false for crashed backends (process already dead).
+    async fn cleanup_evicted_backend(
+        &mut self,
+        instance: BackendInstance,
+        venv_path: &PathBuf,
+        session: u64,
+        client_writer: &mut LspFrameWriter<tokio::io::Stdout>,
+        do_shutdown: bool,
+    ) -> Result<(), ProxyError> {
+        self.cancel_pending_requests_for_backend(client_writer, venv_path, session)
+            .await?;
+        self.clean_pending_backend_requests(venv_path, session);
+        self.clear_diagnostics_for_venv(venv_path, client_writer)
+            .await;
+        if do_shutdown {
+            shutdown_backend_instance(instance);
+        } else {
+            instance.reader_task.abort();
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- Extract `BackendInstance::from_parts()` constructor to consolidate duplicated split→spawn→warmup construction logic (was in `dispatch_initialize` and `create_backend_instance`)
- Extract `cleanup_evicted_backend()` helper to consolidate the 4-step eviction cleanup sequence (was copy-pasted across `evict_lru_backend`, `evict_expired_backends`, and `handle_backend_crash`)
- Refactor `handle_did_open` to delegate to `ensure_backend_in_pool` instead of manually reimplementing evict→create→insert
- **Bug fix**: `handle_backend_crash` now calls `clear_diagnostics_for_venv` via the shared cleanup helper (previously missing — stale diagnostics could persist after a crash)

## Test plan

- [x] `make all` passes (fmt + clippy + test)
- [x] Codex second opinion: LGTM with no issues found
- [x] No behavioral changes except the crash-path diagnostics fix