### PR TITLE
refactor: add BackendError::Communication variant

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -125,7 +125,7 @@ impl LspBackend {
         self.writer
             .write_message(message)
             .await
-            .map_err(|e| BackendError::SpawnFailed(std::io::Error::other(e)))?;
+            .map_err(BackendError::Communication)?;
         Ok(())
     }
 
@@ -134,7 +134,7 @@ impl LspBackend {
         self.reader
             .read_message()
             .await
-            .map_err(|e| BackendError::SpawnFailed(std::io::Error::other(e)))
+            .map_err(BackendError::Communication)
     }
 
     /// Split backend into reader, writer, and child process.
@@ -256,9 +256,7 @@ impl LspBackend {
         // Send SIGTERM (use start_kill since kill may not complete async)
         if let Err(e) = self.child.start_kill() {
             tracing::error!(error = ?e, "Failed to kill backend");
-            return Err(BackendError::SpawnFailed(std::io::Error::other(
-                "Failed to kill backend",
-            )));
+            return Err(BackendError::SpawnFailed(e));
         }
 
         // Wait and confirm termination (with timeout)

--- a/src/backend_pool.rs
+++ b/src/backend_pool.rs
@@ -290,7 +290,7 @@ pub fn spawn_reader_task(
             let result = reader
                 .read_message()
                 .await
-                .map_err(|e| BackendError::SpawnFailed(std::io::Error::other(e)));
+                .map_err(BackendError::Communication);
 
             let is_err = result.is_err();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,9 @@ pub enum BackendError {
     #[error("Failed to spawn backend: {0}")]
     SpawnFailed(#[from] std::io::Error),
 
+    #[error("Backend communication error: {0}")]
+    Communication(#[from] FramingError),
+
     #[error("Initialize timeout after {0}s")]
     InitializeTimeout(u64),
 


### PR DESCRIPTION
## Summary

- Add `BackendError::Communication(FramingError)` variant for post-spawn I/O errors
- Replace 3 sites that misused `SpawnFailed(io::Error::other(e))` to wrap `FramingError`
- Fix `kill_backend` to pass `io::Error` directly instead of fabricating one from a string
- Error logs now show semantically correct variant names

## Test plan

- [x] `make all` passes (fmt + clippy + test)
- [x] No behavioral changes (error propagation paths unchanged)

Closes #32