### PR TITLE
docs: document workspace/symbol limitation with multiple backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ rm -rf ~/.claude/plugins/cache/typemux-cc-marketplace/
 | Symlinks | May fail to detect `pyvenv.cfg` if `.venv` is a symlink | Use actual directory |
 | Late `.venv` creation | venv cached as `None` if `.venv` didn't exist when file was opened | Reopen the file after creating `.venv` |
 | setuptools editable installs | Not a typemux-cc bug. All LSP backends (pyright, ty, pyrefly) cannot resolve imports from setuptools-style editable installs that use import hooks ([ty#475](https://github.com/astral-sh/ty/issues/475)) | Switch build backend to hatchling/flit, or add source paths to `extra-paths` in backend config |
+| `workspace/symbol` with multiple backends | URI-less requests like `workspace/symbol` cannot be routed when multiple backends are active, because there is no file URI to determine the target backend | Works with a single backend; use Grep/Glob as alternative for cross-project symbol search |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Add `workspace/symbol` limitation to Known Limitations table in README
- URI-less LSP requests cannot be routed when multiple backends are active because there is no file URI to determine the target backend
- Single-backend setups are unaffected; Grep/Glob serve as alternatives for cross-project symbol search

## Test plan
- [ ] Verify README renders correctly on GitHub