### PR TITLE
ci: enable auto-generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,5 +54,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ matrix.binary_name }}
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `generate_release_notes: true` to `softprops/action-gh-release` in release workflow
- GitHub will auto-generate release notes from merged PRs and commit history between tags

## Test plan
- [ ] Next `v*` tag push should produce a GitHub Release with auto-generated changelog