### PR TITLE
feat: add --doctor flag for self-diagnosis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,7 @@ dependencies = [
  "assert_cmd",
  "bytes",
  "clap",
+ "libc",
  "lsp-types",
  "predicates",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1.0"
 bytes = "1.9"
 url = "2.5"
 clap = { version = "4.5", features = ["derive", "env"] }
+libc = "0.2"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/README.md
+++ b/README.md
@@ -291,14 +291,51 @@ Each backend process is spawned with `VIRTUAL_ENV` and `PATH` set to point at th
 
 ## Troubleshooting
 
-### LSP Not Working
+### Self-Diagnosis (`--doctor`)
 
-> **Tip**: Enable file logging first: add `TYPEMUX_CC_LOG_FILE=/tmp/typemux-cc.log` to your [config](#configuration).
+Run `--doctor` to dump configuration, environment, and system info at a glance:
 
 ```bash
-which pyright-langserver              # Check if backend is in PATH (or: which ty, which pyrefly)
-cat ~/.claude/settings.json | grep typemux  # Check plugin settings
-tail -100 /tmp/typemux-cc.log        # Check logs
+typemux-cc --doctor
+```
+
+```
+typemux-cc v0.2.8
+
+Configuration:
+  backend         pyright    (default)
+  max_backends    8          (default)
+  backend_ttl     1800       (env: TYPEMUX_CC_BACKEND_TTL)
+  warmup_timeout  2          (default)
+  fanout_timeout  5          (default)
+  log_file        <not set>  (default)
+
+Environment:
+  Backend binary    pyright-langserver
+    Path            /usr/local/bin/pyright-langserver
+    Version         pyright 1.1.350
+  Git toplevel      /Users/foo/project
+  Fallback venv     /Users/foo/project/.venv
+
+System:
+  OS                macos (Darwin 24.0.0)
+  Arch              aarch64
+```
+
+Add `--json` for machine-readable output:
+
+```bash
+typemux-cc --doctor --json
+```
+
+### LSP Not Working
+
+> **Tip**: Run `typemux-cc --doctor` first to check your configuration and backend availability. For detailed logs, add `TYPEMUX_CC_LOG_FILE=/tmp/typemux-cc.log` to your [config](#configuration).
+
+```bash
+typemux-cc --doctor                          # Quick self-diagnosis
+cat ~/.claude/settings.json | grep typemux   # Check plugin settings
+tail -100 /tmp/typemux-cc.log               # Check logs (if file logging enabled)
 ```
 
 ### Plugin Update Not Taking Effect

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -24,9 +24,19 @@ impl BackendKind {
         }
     }
 
-    fn command(&self) -> &'static str {
+    pub fn command(&self) -> &'static str {
         match self {
             Self::Pyright => "pyright-langserver",
+            Self::Ty => "ty",
+            Self::Pyrefly => "pyrefly",
+        }
+    }
+
+    /// Command name used for `--version` detection.
+    /// pyright-langserver does not support `--version`, so we use `pyright` instead.
+    pub fn version_command(&self) -> &'static str {
+        match self {
+            Self::Pyright => "pyright",
             Self::Ty => "ty",
             Self::Pyrefly => "pyrefly",
         }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,468 @@
+use crate::backend::BackendKind;
+use crate::backend_pool;
+use crate::venv;
+use clap::parser::ValueSource;
+use clap::ArgMatches;
+use serde::Serialize;
+use std::path::PathBuf;
+
+/// Top-level doctor report.
+#[derive(Debug, Serialize)]
+pub struct DoctorReport {
+    pub version: String,
+    pub configuration: ConfigReport,
+    pub environment: EnvironmentReport,
+    pub system: SystemReport,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConfigReport {
+    pub items: Vec<ConfigItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ConfigItem {
+    pub name: String,
+    pub value: String,
+    pub source: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EnvironmentReport {
+    pub backend_binary: BackendBinaryInfo,
+    pub git_toplevel: Option<String>,
+    pub fallback_venv: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BackendBinaryInfo {
+    pub command: String,
+    pub path: Option<String>,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SystemReport {
+    pub os: String,
+    pub arch: String,
+}
+
+/// Determine the source label for a CLI argument.
+fn arg_source(matches: &ArgMatches, id: &str) -> String {
+    match matches.value_source(id) {
+        Some(ValueSource::CommandLine) => "cli".to_string(),
+        Some(ValueSource::EnvVariable) => format!("env: {}", env_var_name(id)),
+        Some(ValueSource::DefaultValue) => "default".to_string(),
+        _ => "default".to_string(),
+    }
+}
+
+/// Map arg id to its environment variable name.
+fn env_var_name(id: &str) -> &'static str {
+    match id {
+        "backend" => "TYPEMUX_CC_BACKEND",
+        "max_backends" => "TYPEMUX_CC_MAX_BACKENDS",
+        "backend_ttl" => "TYPEMUX_CC_BACKEND_TTL",
+        "log_file" => "TYPEMUX_CC_LOG_FILE",
+        _ => "UNKNOWN",
+    }
+}
+
+/// Determine source for env-var-only settings (no CLI arg).
+fn env_only_source(env_var: &str) -> String {
+    if std::env::var(env_var).is_ok() {
+        format!("env: {}", env_var)
+    } else {
+        "default".to_string()
+    }
+}
+
+/// Search for a binary in PATH directories using std::env::split_paths + metadata.
+/// Returns the first match that is a file with execute permission.
+pub fn find_binary_in_path(binary_name: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(binary_name);
+        if let Ok(meta) = std::fs::metadata(&candidate) {
+            if meta.is_file() && is_executable(&meta) {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_executable(meta: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    meta.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
+fn is_executable(_meta: &std::fs::Metadata) -> bool {
+    // On non-Unix platforms, assume files in PATH are executable.
+    true
+}
+
+/// Run `<command> --version` and return stdout, or an error description.
+async fn detect_backend_version(command: &str) -> Option<String> {
+    let child = match tokio::process::Command::new(command)
+        .arg("--version")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(e) => return Some(format!("failed to run: {}", e)),
+    };
+
+    match child.wait_with_output().await {
+        Ok(out) if out.status.success() => {
+            let version = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if version.is_empty() {
+                // Some tools print version to stderr
+                let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+                if stderr.is_empty() {
+                    Some("(empty output)".to_string())
+                } else {
+                    Some(stderr)
+                }
+            } else {
+                Some(version)
+            }
+        }
+        Ok(out) => Some(format!(
+            "exit code {}: {}",
+            out.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&out.stderr).trim()
+        )),
+        Err(e) => Some(format!("failed to read output: {}", e)),
+    }
+}
+
+/// Collect all diagnostic information into a DoctorReport.
+pub async fn collect_doctor_report(backend: &BackendKind, matches: &ArgMatches) -> DoctorReport {
+    let version = env!("CARGO_PKG_VERSION").to_string();
+
+    // Configuration items from clap ArgMatches
+    let backend_item = ConfigItem {
+        name: "backend".to_string(),
+        value: backend.display_name().to_string(),
+        source: arg_source(matches, "backend"),
+    };
+
+    let max_backends_value: String = matches
+        .get_one::<u64>("max_backends")
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "8".to_string());
+    let max_backends_item = ConfigItem {
+        name: "max_backends".to_string(),
+        value: max_backends_value,
+        source: arg_source(matches, "max_backends"),
+    };
+
+    let backend_ttl_value: String = matches
+        .get_one::<u64>("backend_ttl")
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "1800".to_string());
+    let backend_ttl_item = ConfigItem {
+        name: "backend_ttl".to_string(),
+        value: backend_ttl_value,
+        source: arg_source(matches, "backend_ttl"),
+    };
+
+    let warmup_timeout = backend_pool::warmup_timeout();
+    let warmup_timeout_item = ConfigItem {
+        name: "warmup_timeout".to_string(),
+        value: warmup_timeout.as_secs().to_string(),
+        source: env_only_source("TYPEMUX_CC_WARMUP_TIMEOUT"),
+    };
+
+    let fanout_timeout = backend_pool::fanout_timeout();
+    let fanout_timeout_item = ConfigItem {
+        name: "fanout_timeout".to_string(),
+        value: fanout_timeout.as_secs().to_string(),
+        source: env_only_source("TYPEMUX_CC_FANOUT_TIMEOUT"),
+    };
+
+    let log_file_value: String = matches
+        .get_one::<PathBuf>("log_file")
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<not set>".to_string());
+    let log_file_source = if matches.value_source("log_file") == Some(ValueSource::DefaultValue)
+        || matches.value_source("log_file").is_none()
+    {
+        "default".to_string()
+    } else {
+        arg_source(matches, "log_file")
+    };
+    let log_file_item = ConfigItem {
+        name: "log_file".to_string(),
+        value: log_file_value,
+        source: log_file_source,
+    };
+
+    let config = ConfigReport {
+        items: vec![
+            backend_item,
+            max_backends_item,
+            backend_ttl_item,
+            warmup_timeout_item,
+            fanout_timeout_item,
+            log_file_item,
+        ],
+    };
+
+    // Environment: backend binary
+    let cmd_name = backend.command();
+    let binary_path = find_binary_in_path(cmd_name);
+    let version_cmd = backend.version_command();
+    let backend_version = detect_backend_version(version_cmd).await;
+    let backend_binary = BackendBinaryInfo {
+        command: cmd_name.to_string(),
+        path: binary_path.map(|p| p.display().to_string()),
+        version: backend_version,
+    };
+
+    // Environment: git toplevel and fallback venv
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let git_toplevel = venv::get_git_toplevel(&cwd).await.ok().flatten();
+    let fallback_venv = venv::find_fallback_venv(&cwd).await.ok().flatten();
+
+    let environment = EnvironmentReport {
+        backend_binary,
+        git_toplevel: git_toplevel.map(|p| p.display().to_string()),
+        fallback_venv: fallback_venv.map(|p| p.display().to_string()),
+    };
+
+    // System info
+    let system = SystemReport {
+        os: format!("{} ({})", std::env::consts::OS, os_version()),
+        arch: std::env::consts::ARCH.to_string(),
+    };
+
+    DoctorReport {
+        version,
+        configuration: config,
+        environment,
+        system,
+    }
+}
+
+/// Get OS kernel version string.
+fn os_version() -> String {
+    #[cfg(unix)]
+    {
+        let mut utsname = std::mem::MaybeUninit::<libc::utsname>::uninit();
+        let ret = unsafe { libc::uname(utsname.as_mut_ptr()) };
+        if ret == 0 {
+            let utsname = unsafe { utsname.assume_init() };
+            let sysname = unsafe { std::ffi::CStr::from_ptr(utsname.sysname.as_ptr()) };
+            let release = unsafe { std::ffi::CStr::from_ptr(utsname.release.as_ptr()) };
+            return format!(
+                "{} {}",
+                sysname.to_string_lossy(),
+                release.to_string_lossy()
+            );
+        }
+    }
+    "unknown".to_string()
+}
+
+/// Render the report in human-readable aligned columns.
+pub fn render_human(report: &DoctorReport) -> String {
+    let mut out = String::new();
+
+    out.push_str(&format!("typemux-cc v{}\n", report.version));
+    out.push_str("\nConfiguration:\n");
+
+    // Find max key and value widths for alignment
+    let max_key = report
+        .configuration
+        .items
+        .iter()
+        .map(|i| i.name.len())
+        .max()
+        .unwrap_or(0);
+    let max_val = report
+        .configuration
+        .items
+        .iter()
+        .map(|i| i.value.len())
+        .max()
+        .unwrap_or(0);
+
+    for item in &report.configuration.items {
+        out.push_str(&format!(
+            "  {:<kw$}  {:<vw$}  ({})\n",
+            item.name,
+            item.value,
+            item.source,
+            kw = max_key,
+            vw = max_val,
+        ));
+    }
+
+    out.push_str("\nEnvironment:\n");
+    out.push_str(&format!(
+        "  Backend binary    {}\n",
+        report.environment.backend_binary.command
+    ));
+    out.push_str(&format!(
+        "    Path            {}\n",
+        report
+            .environment
+            .backend_binary
+            .path
+            .as_deref()
+            .unwrap_or("<not found>")
+    ));
+    out.push_str(&format!(
+        "    Version         {}\n",
+        report
+            .environment
+            .backend_binary
+            .version
+            .as_deref()
+            .unwrap_or("<unknown>")
+    ));
+    out.push_str(&format!(
+        "  Git toplevel      {}\n",
+        report
+            .environment
+            .git_toplevel
+            .as_deref()
+            .unwrap_or("<not in a git repo>")
+    ));
+    out.push_str(&format!(
+        "  Fallback venv     {}\n",
+        report
+            .environment
+            .fallback_venv
+            .as_deref()
+            .unwrap_or("<not found>")
+    ));
+
+    out.push_str("\nSystem:\n");
+    out.push_str(&format!("  OS                {}\n", report.system.os));
+    out.push_str(&format!("  Arch              {}\n", report.system.arch));
+
+    out
+}
+
+/// Entry point: collect report, render, and print to stdout. Always exits 0.
+pub async fn run_doctor(backend: &BackendKind, json: bool, matches: &ArgMatches) {
+    let report = collect_doctor_report(backend, matches).await;
+
+    if json {
+        match serde_json::to_string_pretty(&report) {
+            Ok(json_str) => print!("{}", json_str),
+            Err(e) => eprintln!("Failed to serialize doctor report: {}", e),
+        }
+    } else {
+        print!("{}", render_human(&report));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_binary_in_path_finds_sh() {
+        // /bin/sh should exist on all Unix systems
+        let result = find_binary_in_path("sh");
+        assert!(result.is_some(), "sh should be found in PATH");
+    }
+
+    #[test]
+    fn find_binary_in_path_returns_none_for_nonexistent() {
+        let result = find_binary_in_path("this-binary-does-not-exist-12345");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn render_human_output_structure() {
+        let report = DoctorReport {
+            version: "0.2.8".to_string(),
+            configuration: ConfigReport {
+                items: vec![
+                    ConfigItem {
+                        name: "backend".to_string(),
+                        value: "pyright".to_string(),
+                        source: "default".to_string(),
+                    },
+                    ConfigItem {
+                        name: "max_backends".to_string(),
+                        value: "8".to_string(),
+                        source: "default".to_string(),
+                    },
+                ],
+            },
+            environment: EnvironmentReport {
+                backend_binary: BackendBinaryInfo {
+                    command: "pyright-langserver".to_string(),
+                    path: Some("/usr/local/bin/pyright-langserver".to_string()),
+                    version: Some("pyright 1.1.350".to_string()),
+                },
+                git_toplevel: Some("/Users/test/project".to_string()),
+                fallback_venv: Some("/Users/test/project/.venv".to_string()),
+            },
+            system: SystemReport {
+                os: "macos (Darwin 24.0.0)".to_string(),
+                arch: "aarch64".to_string(),
+            },
+        };
+
+        let output = render_human(&report);
+
+        assert!(output.starts_with("typemux-cc v0.2.8\n"));
+        assert!(output.contains("Configuration:"));
+        assert!(output.contains("backend"));
+        assert!(output.contains("pyright"));
+        assert!(output.contains("(default)"));
+        assert!(output.contains("Environment:"));
+        assert!(output.contains("Backend binary"));
+        assert!(output.contains("pyright-langserver"));
+        assert!(output.contains("System:"));
+        assert!(output.contains("aarch64"));
+    }
+
+    #[test]
+    fn render_human_handles_missing_values() {
+        let report = DoctorReport {
+            version: "0.2.8".to_string(),
+            configuration: ConfigReport { items: vec![] },
+            environment: EnvironmentReport {
+                backend_binary: BackendBinaryInfo {
+                    command: "pyright-langserver".to_string(),
+                    path: None,
+                    version: None,
+                },
+                git_toplevel: None,
+                fallback_venv: None,
+            },
+            system: SystemReport {
+                os: "linux".to_string(),
+                arch: "x86_64".to_string(),
+            },
+        };
+
+        let output = render_human(&report);
+        assert!(output.contains("<not found>"));
+        assert!(output.contains("<unknown>"));
+        assert!(output.contains("<not in a git repo>"));
+    }
+
+    #[test]
+    fn config_item_serializes_correctly() {
+        let item = ConfigItem {
+            name: "backend".to_string(),
+            value: "pyright".to_string(),
+            source: "default".to_string(),
+        };
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(json.contains("\"name\":\"backend\""));
+        assert!(json.contains("\"source\":\"default\""));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod backend;
 mod backend_pool;
+mod doctor;
 mod proxy;
 
 pub use typemux_cc::{error, framing, message};
@@ -8,7 +9,7 @@ mod text_edit;
 mod venv;
 
 use backend::BackendKind;
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches, Parser};
 use proxy::LspProxy;
 use std::path::PathBuf;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
@@ -41,11 +42,25 @@ struct Args {
         value_enum
     )]
     backend: BackendKind,
+
+    /// Run self-diagnosis and print configuration/environment info
+    #[arg(long)]
+    doctor: bool,
+
+    /// Output doctor report as JSON (requires --doctor)
+    #[arg(long, requires = "doctor")]
+    json: bool,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let args = Args::parse();
+    let matches = Args::command().get_matches();
+    let args = Args::from_arg_matches(&matches)?;
+
+    if args.doctor {
+        doctor::run_doctor(&args.backend, args.json, &matches).await;
+        return Ok(());
+    }
 
     // Initialize logging (default: stderr, --log-file adds file output)
     if let Some(log_path) = &args.log_file {

--- a/tests/doctor_test.rs
+++ b/tests/doctor_test.rs
@@ -1,0 +1,65 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn doctor_exits_zero_with_human_output() {
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.arg("--doctor");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::starts_with("typemux-cc v"))
+        .stdout(predicate::str::contains("Configuration:"))
+        .stdout(predicate::str::contains("backend"))
+        .stdout(predicate::str::contains("Environment:"))
+        .stdout(predicate::str::contains("System:"))
+        .stdout(predicate::str::contains("OS"))
+        .stdout(predicate::str::contains("Arch"));
+}
+
+#[test]
+fn doctor_json_outputs_valid_json() {
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.arg("--doctor").arg("--json");
+
+    let output = cmd.output().expect("failed to run");
+    assert!(output.status.success());
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
+
+    assert!(json.get("version").is_some());
+    assert!(json.get("configuration").is_some());
+    assert!(json.get("environment").is_some());
+    assert!(json.get("system").is_some());
+}
+
+#[test]
+fn json_without_doctor_fails() {
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.arg("--json");
+
+    cmd.assert().failure();
+}
+
+#[test]
+fn doctor_with_backend_flag() {
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.arg("--doctor").arg("--backend").arg("ty");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("ty"))
+        .stdout(predicate::str::contains("(cli)"));
+}
+
+#[test]
+fn doctor_with_env_var_source() {
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.arg("--doctor").env("TYPEMUX_CC_MAX_BACKENDS", "4");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("4"))
+        .stdout(predicate::str::contains("env: TYPEMUX_CC_MAX_BACKENDS"));
+}


### PR DESCRIPTION
## Summary

- Add `--doctor` flag that prints configuration sources, backend binary path/version, git toplevel, fallback venv, and system info in aligned columns
- Add `--json` flag (requires `--doctor`) for machine-readable JSON output
- Uses clap `value_source()` for accurate config source detection (cli/env/default)
- Binary path detection via `std::env::split_paths` + metadata (no external `which` dependency)
- Partial failures are embedded in the report; doctor always exits 0

## Changes

| File | Change |
|------|--------|
| `src/doctor.rs` | New: DoctorReport structs, collect/render logic, unit tests |
| `src/main.rs` | Add `--doctor`/`--json` flags, ArgMatches-based parsing, early return |
| `src/backend.rs` | Make `command()` pub, add `version_command()` for version detection |
| `tests/doctor_test.rs` | New: 5 integration tests (human, JSON, error, cli source, env source) |
| `README.md` | Add Self-Diagnosis section to Troubleshooting |
| `Cargo.toml` | Add `libc` dependency for OS version detection |

## Test plan

- [x] `cargo run --bin typemux-cc -- --doctor` → human-readable output, exit 0
- [x] `cargo run --bin typemux-cc -- --doctor --json` → valid JSON, exit 0
- [x] `cargo run --bin typemux-cc -- --doctor --backend ty` → shows ty with (cli) source
- [x] `TYPEMUX_CC_MAX_BACKENDS=4 cargo run --bin typemux-cc -- --doctor` → shows (env: TYPEMUX_CC_MAX_BACKENDS)
- [x] `cargo run --bin typemux-cc -- --json` → error (requires --doctor)
- [x] `make all` → fmt + clippy + all tests pass

Closes #46