### PR TITLE
feat: load config file natively in binary, remove wrapper dependency

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,7 +12,7 @@
   "hooks": "./hooks.json",
   "lspServers": {
     "typemux-cc": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/bin/typemux-cc-wrapper.sh",
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/typemux-cc",
       "args": [],
       "extensionToLanguage": {
         ".py": "python",

--- a/README.md
+++ b/README.md
@@ -169,56 +169,35 @@ cargo build --release
 
 ## Usage
 
-Automatically starts as a Claude Code plugin. For manual execution:
-
-```bash
-./target/release/typemux-cc
-./target/release/typemux-cc --help
-```
-
-### Backend Selection
-
-```bash
-# Via CLI flag
-./target/release/typemux-cc --backend ty
-
-# Via environment variable
-TYPEMUX_CC_BACKEND=ty ./target/release/typemux-cc
-```
+Automatically starts as a Claude Code plugin — no manual setup required.
 
 ### Configuration
 
-To configure the backend via the wrapper script (persistent across sessions):
+Settings are stored in `~/.config/typemux-cc/config`. The file uses `KEY=VALUE` format (shell expansion is **not** supported):
 
 ```bash
 mkdir -p ~/.config/typemux-cc
 cat > ~/.config/typemux-cc/config << 'EOF'
 # Select backend (pyright, ty, or pyrefly)
-export TYPEMUX_CC_BACKEND="pyright"
+TYPEMUX_CC_BACKEND=pyright
 
-# Enable file output
-export TYPEMUX_CC_LOG_FILE="/tmp/typemux-cc.log"
+# Enable file logging
+TYPEMUX_CC_LOG_FILE=/tmp/typemux-cc.log
 EOF
 ```
 
-### Logging
+> **Note:** `export KEY=VALUE` syntax is also accepted for compatibility with older config files.
 
-Default output is stderr. For file output:
+Settings priority: **CLI flag > environment variable > config file > default**
 
-```bash
-TYPEMUX_CC_LOG_FILE=/tmp/typemux-cc.log ./target/release/typemux-cc
-```
-
-| Environment Variable | Description | Default |
-|----------------------|-------------|---------|
+| Variable | Description | Default |
+|----------|-------------|---------|
 | `TYPEMUX_CC_LOG_FILE` | Log file path | Not set (stderr only) |
 | `TYPEMUX_CC_BACKEND` | LSP backend to use | `pyright` |
 | `TYPEMUX_CC_MAX_BACKENDS` | Max concurrent backend processes | `8` |
 | `TYPEMUX_CC_BACKEND_TTL` | Backend TTL in seconds (0 = disabled) | `1800` |
 | `TYPEMUX_CC_FANOUT_TIMEOUT` | Fan-out timeout in seconds for `workspace/symbol` (0 = no timeout) | `5` |
 | `RUST_LOG` | Log level | `typemux_cc=debug` |
-
-For config file method and details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 
 ## Typical Use Case
 
@@ -296,19 +275,28 @@ Each backend process is spawned with `VIRTUAL_ENV` and `PATH` set to point at th
 Run `--doctor` to dump configuration, environment, and system info at a glance:
 
 ```bash
-typemux-cc --doctor
+# Find the binary in the plugin cache, then run --doctor
+ls ~/.claude/plugins/cache/typemux-cc-marketplace/typemux-cc/
+# → 0.2.9
+~/.claude/plugins/cache/typemux-cc-marketplace/typemux-cc/0.2.9/bin/typemux-cc --doctor
 ```
 
+The binary reads `~/.config/typemux-cc/config` directly, so your settings are reflected in the output:
+
 ```
-typemux-cc v0.2.8
+typemux-cc v0.2.9
+
+Config file:
+  Path              /Users/foo/.config/typemux-cc/config
+  Status            loaded
 
 Configuration:
-  backend         pyright    (default)
-  max_backends    8          (default)
-  backend_ttl     1800       (env: TYPEMUX_CC_BACKEND_TTL)
-  warmup_timeout  2          (default)
-  fanout_timeout  5          (default)
-  log_file        <not set>  (default)
+  backend         pyright              (default)
+  max_backends    8                    (default)
+  backend_ttl     1800                 (default)
+  warmup_timeout  2                    (default)
+  fanout_timeout  5                    (default)
+  log_file        /tmp/typemux-cc.log  (config: /Users/foo/.config/typemux-cc/config)
 
 Environment:
   Backend binary    pyright-langserver
@@ -325,15 +313,16 @@ System:
 Add `--json` for machine-readable output:
 
 ```bash
-typemux-cc --doctor --json
+~/.claude/plugins/cache/typemux-cc-marketplace/typemux-cc/0.2.9/bin/typemux-cc --doctor --json
 ```
 
 ### LSP Not Working
 
-> **Tip**: Run `typemux-cc --doctor` first to check your configuration and backend availability. For detailed logs, add `TYPEMUX_CC_LOG_FILE=/tmp/typemux-cc.log` to your [config](#configuration).
+> **Tip**: Run `--doctor` first to check your configuration and backend availability. For detailed logs, add `TYPEMUX_CC_LOG_FILE=/tmp/typemux-cc.log` to your [config](#configuration).
 
 ```bash
-typemux-cc --doctor                          # Quick self-diagnosis
+# Quick self-diagnosis (replace version number as needed)
+~/.claude/plugins/cache/typemux-cc-marketplace/typemux-cc/0.2.9/bin/typemux-cc --doctor
 cat ~/.claude/settings.json | grep typemux   # Check plugin settings
 tail -100 /tmp/typemux-cc.log               # Check logs (if file logging enabled)
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,241 @@
+use std::path::PathBuf;
+
+/// A single parse error with location context.
+#[derive(Debug, Clone)]
+pub struct ParseError {
+    pub line_number: usize,
+    pub raw_line: String,
+    pub reason: String,
+}
+
+/// Report from loading the config file, used by doctor for provenance tracking.
+#[derive(Debug)]
+pub struct ConfigLoadReport {
+    pub path: PathBuf,
+    pub exists: bool,
+    pub loaded_keys: Vec<String>,
+    pub skipped_keys: Vec<String>,
+    pub parse_errors: Vec<ParseError>,
+}
+
+/// Default config file path: `~/.config/typemux-cc/config`
+fn default_config_path() -> Option<PathBuf> {
+    dirs_fallback_home().map(|home| home.join(".config").join("typemux-cc").join("config"))
+}
+
+/// Get home directory without external crates.
+fn dirs_fallback_home() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+/// Parse a single non-empty, non-comment line into (key, value).
+///
+/// Supports:
+///   KEY=VALUE
+///   export KEY=VALUE
+///   KEY="VALUE"  /  KEY='VALUE'
+///
+/// Does NOT support shell expansion ($HOME, command substitution, etc.).
+fn parse_line(line: &str) -> Result<(String, String), String> {
+    let trimmed = line.trim();
+
+    // Strip optional `export ` prefix
+    let trimmed = trimmed
+        .strip_prefix("export ")
+        .unwrap_or(trimmed)
+        .trim_start();
+
+    let eq_pos = trimmed
+        .find('=')
+        .ok_or_else(|| "missing '=' delimiter".to_string())?;
+
+    let key = trimmed[..eq_pos].trim();
+    if key.is_empty() {
+        return Err("empty key".to_string());
+    }
+    if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return Err(format!("invalid key characters: {}", key));
+    }
+
+    let mut value = trimmed[eq_pos + 1..].trim().to_string();
+
+    // Strip matching quotes
+    if ((value.starts_with('"') && value.ends_with('"'))
+        || (value.starts_with('\'') && value.ends_with('\'')))
+        && value.len() >= 2
+    {
+        value = value[1..value.len() - 1].to_string();
+    }
+
+    // Reject shell expansion patterns
+    if value.contains("$(") || value.contains('`') {
+        return Err("shell command substitution is not supported".to_string());
+    }
+    if value.contains('$') {
+        return Err("shell variable expansion is not supported".to_string());
+    }
+
+    Ok((key.to_string(), value))
+}
+
+/// Load config file and set environment variables.
+///
+/// - Reads `~/.config/typemux-cc/config`
+/// - Sets env vars only if they are not already set (existing env takes priority)
+/// - Duplicate keys within config: last wins
+/// - Must be called BEFORE clap argument parsing
+pub fn load_config_file() -> ConfigLoadReport {
+    let path = default_config_path().unwrap_or_else(|| PathBuf::from(""));
+
+    let content = match std::fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(_) => {
+            return ConfigLoadReport {
+                exists: !path.as_os_str().is_empty() && path.exists(),
+                path,
+                loaded_keys: vec![],
+                skipped_keys: vec![],
+                parse_errors: vec![],
+            };
+        }
+    };
+
+    let mut loaded_keys = Vec::new();
+    let mut skipped_keys = Vec::new();
+    let mut parse_errors = Vec::new();
+
+    // First pass: collect all key-value pairs (last wins for duplicates)
+    let mut entries: Vec<(String, String)> = Vec::new();
+    for (i, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        match parse_line(line) {
+            Ok((key, value)) => {
+                // Last wins: remove earlier entry for the same key
+                entries.retain(|(k, _)| k != &key);
+                entries.push((key, value));
+            }
+            Err(reason) => {
+                parse_errors.push(ParseError {
+                    line_number: i + 1,
+                    raw_line: line.to_string(),
+                    reason,
+                });
+            }
+        }
+    }
+
+    // Second pass: set env vars (skip if already set)
+    for (key, value) in entries {
+        if std::env::var_os(&key).is_some() {
+            skipped_keys.push(key);
+        } else {
+            // SAFETY: called before any threads are spawned (before tokio runtime)
+            unsafe {
+                std::env::set_var(&key, &value);
+            }
+            loaded_keys.push(key);
+        }
+    }
+
+    ConfigLoadReport {
+        exists: true,
+        path,
+        loaded_keys,
+        skipped_keys,
+        parse_errors,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_key_value() {
+        let (k, v) = parse_line("FOO=bar").unwrap();
+        assert_eq!(k, "FOO");
+        assert_eq!(v, "bar");
+    }
+
+    #[test]
+    fn parse_export_prefix() {
+        let (k, v) = parse_line("export FOO=bar").unwrap();
+        assert_eq!(k, "FOO");
+        assert_eq!(v, "bar");
+    }
+
+    #[test]
+    fn parse_quoted_value_double() {
+        let (k, v) = parse_line(r#"FOO="hello world""#).unwrap();
+        assert_eq!(k, "FOO");
+        assert_eq!(v, "hello world");
+    }
+
+    #[test]
+    fn parse_quoted_value_single() {
+        let (k, v) = parse_line("FOO='hello world'").unwrap();
+        assert_eq!(k, "FOO");
+        assert_eq!(v, "hello world");
+    }
+
+    #[test]
+    fn parse_export_with_quotes() {
+        let (k, v) = parse_line(r#"export MY_VAR="/some/path""#).unwrap();
+        assert_eq!(k, "MY_VAR");
+        assert_eq!(v, "/some/path");
+    }
+
+    #[test]
+    fn reject_shell_variable() {
+        let err = parse_line("FOO=$HOME/bar").unwrap_err();
+        assert!(err.contains("variable expansion"));
+    }
+
+    #[test]
+    fn reject_command_substitution() {
+        let err = parse_line("FOO=$(whoami)").unwrap_err();
+        assert!(err.contains("command substitution"));
+    }
+
+    #[test]
+    fn reject_backtick_substitution() {
+        let err = parse_line("FOO=`whoami`").unwrap_err();
+        assert!(err.contains("command substitution"));
+    }
+
+    #[test]
+    fn reject_missing_equals() {
+        let err = parse_line("FOOBAR").unwrap_err();
+        assert!(err.contains("missing '='"));
+    }
+
+    #[test]
+    fn reject_empty_key() {
+        let err = parse_line("=value").unwrap_err();
+        assert!(err.contains("empty key"));
+    }
+
+    #[test]
+    fn reject_invalid_key_chars() {
+        let err = parse_line("FOO-BAR=value").unwrap_err();
+        assert!(err.contains("invalid key"));
+    }
+
+    #[test]
+    fn parse_empty_value() {
+        let (k, v) = parse_line("FOO=").unwrap();
+        assert_eq!(k, "FOO");
+        assert_eq!(v, "");
+    }
+
+    #[test]
+    fn parse_value_with_equals() {
+        let (k, v) = parse_line("FOO=bar=baz").unwrap();
+        assert_eq!(k, "FOO");
+        assert_eq!(v, "bar=baz");
+    }
+}

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,5 +1,6 @@
 use crate::backend::BackendKind;
 use crate::backend_pool;
+use crate::config::ConfigLoadReport;
 use crate::venv;
 use clap::parser::ValueSource;
 use clap::ArgMatches;
@@ -10,9 +11,19 @@ use std::path::PathBuf;
 #[derive(Debug, Serialize)]
 pub struct DoctorReport {
     pub version: String,
+    pub config_file: ConfigFileReport,
     pub configuration: ConfigReport,
     pub environment: EnvironmentReport,
     pub system: SystemReport,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConfigFileReport {
+    pub path: String,
+    pub exists: bool,
+    pub loaded_keys: Vec<String>,
+    pub skipped_keys: Vec<String>,
+    pub parse_errors: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -47,11 +58,19 @@ pub struct SystemReport {
     pub arch: String,
 }
 
-/// Determine the source label for a CLI argument.
-fn arg_source(matches: &ArgMatches, id: &str) -> String {
+/// Determine the source label for a CLI argument, with config-file provenance.
+fn arg_source(matches: &ArgMatches, id: &str, config_report: &ConfigLoadReport) -> String {
     match matches.value_source(id) {
         Some(ValueSource::CommandLine) => "cli".to_string(),
-        Some(ValueSource::EnvVariable) => format!("env: {}", env_var_name(id)),
+        Some(ValueSource::EnvVariable) => {
+            let env_name = env_var_name(id);
+            // If this env var was loaded from config file, report as config source
+            if config_report.loaded_keys.contains(&env_name.to_string()) {
+                format!("config: {}", config_report.path.display())
+            } else {
+                format!("env: {}", env_name)
+            }
+        }
         Some(ValueSource::DefaultValue) => "default".to_string(),
         _ => "default".to_string(),
     }
@@ -68,10 +87,14 @@ fn env_var_name(id: &str) -> &'static str {
     }
 }
 
-/// Determine source for env-var-only settings (no CLI arg).
-fn env_only_source(env_var: &str) -> String {
+/// Determine source for env-var-only settings (no CLI arg), with config-file provenance.
+fn env_only_source(env_var: &str, config_report: &ConfigLoadReport) -> String {
     if std::env::var(env_var).is_ok() {
-        format!("env: {}", env_var)
+        if config_report.loaded_keys.contains(&env_var.to_string()) {
+            format!("config: {}", config_report.path.display())
+        } else {
+            format!("env: {}", env_var)
+        }
     } else {
         "default".to_string()
     }
@@ -141,14 +164,31 @@ async fn detect_backend_version(command: &str) -> Option<String> {
 }
 
 /// Collect all diagnostic information into a DoctorReport.
-pub async fn collect_doctor_report(backend: &BackendKind, matches: &ArgMatches) -> DoctorReport {
+pub async fn collect_doctor_report(
+    backend: &BackendKind,
+    matches: &ArgMatches,
+    config_report: &ConfigLoadReport,
+) -> DoctorReport {
     let version = env!("CARGO_PKG_VERSION").to_string();
+
+    // Config file report
+    let config_file = ConfigFileReport {
+        path: config_report.path.display().to_string(),
+        exists: config_report.exists,
+        loaded_keys: config_report.loaded_keys.clone(),
+        skipped_keys: config_report.skipped_keys.clone(),
+        parse_errors: config_report
+            .parse_errors
+            .iter()
+            .map(|e| format!("line {}: {} ({})", e.line_number, e.reason, e.raw_line))
+            .collect(),
+    };
 
     // Configuration items from clap ArgMatches
     let backend_item = ConfigItem {
         name: "backend".to_string(),
         value: backend.display_name().to_string(),
-        source: arg_source(matches, "backend"),
+        source: arg_source(matches, "backend", config_report),
     };
 
     let max_backends_value: String = matches
@@ -158,7 +198,7 @@ pub async fn collect_doctor_report(backend: &BackendKind, matches: &ArgMatches) 
     let max_backends_item = ConfigItem {
         name: "max_backends".to_string(),
         value: max_backends_value,
-        source: arg_source(matches, "max_backends"),
+        source: arg_source(matches, "max_backends", config_report),
     };
 
     let backend_ttl_value: String = matches
@@ -168,21 +208,21 @@ pub async fn collect_doctor_report(backend: &BackendKind, matches: &ArgMatches) 
     let backend_ttl_item = ConfigItem {
         name: "backend_ttl".to_string(),
         value: backend_ttl_value,
-        source: arg_source(matches, "backend_ttl"),
+        source: arg_source(matches, "backend_ttl", config_report),
     };
 
     let warmup_timeout = backend_pool::warmup_timeout();
     let warmup_timeout_item = ConfigItem {
         name: "warmup_timeout".to_string(),
         value: warmup_timeout.as_secs().to_string(),
-        source: env_only_source("TYPEMUX_CC_WARMUP_TIMEOUT"),
+        source: env_only_source("TYPEMUX_CC_WARMUP_TIMEOUT", config_report),
     };
 
     let fanout_timeout = backend_pool::fanout_timeout();
     let fanout_timeout_item = ConfigItem {
         name: "fanout_timeout".to_string(),
         value: fanout_timeout.as_secs().to_string(),
-        source: env_only_source("TYPEMUX_CC_FANOUT_TIMEOUT"),
+        source: env_only_source("TYPEMUX_CC_FANOUT_TIMEOUT", config_report),
     };
 
     let log_file_value: String = matches
@@ -194,7 +234,7 @@ pub async fn collect_doctor_report(backend: &BackendKind, matches: &ArgMatches) 
     {
         "default".to_string()
     } else {
-        arg_source(matches, "log_file")
+        arg_source(matches, "log_file", config_report)
     };
     let log_file_item = ConfigItem {
         name: "log_file".to_string(),
@@ -243,6 +283,7 @@ pub async fn collect_doctor_report(backend: &BackendKind, matches: &ArgMatches) 
 
     DoctorReport {
         version,
+        config_file,
         configuration: config,
         environment,
         system,
@@ -274,6 +315,28 @@ pub fn render_human(report: &DoctorReport) -> String {
     let mut out = String::new();
 
     out.push_str(&format!("typemux-cc v{}\n", report.version));
+
+    // Config file info
+    out.push_str("\nConfig file:\n");
+    out.push_str(&format!(
+        "  Path              {}\n",
+        report.config_file.path
+    ));
+    out.push_str(&format!(
+        "  Status            {}\n",
+        if report.config_file.exists {
+            "loaded"
+        } else {
+            "not found"
+        }
+    ));
+    if !report.config_file.parse_errors.is_empty() {
+        out.push_str("  Warnings:\n");
+        for err in &report.config_file.parse_errors {
+            out.push_str(&format!("    ⚠ {}\n", err));
+        }
+    }
+
     out.push_str("\nConfiguration:\n");
 
     // Find max key and value widths for alignment
@@ -351,8 +414,13 @@ pub fn render_human(report: &DoctorReport) -> String {
 }
 
 /// Entry point: collect report, render, and print to stdout. Always exits 0.
-pub async fn run_doctor(backend: &BackendKind, json: bool, matches: &ArgMatches) {
-    let report = collect_doctor_report(backend, matches).await;
+pub async fn run_doctor(
+    backend: &BackendKind,
+    json: bool,
+    matches: &ArgMatches,
+    config_report: &ConfigLoadReport,
+) {
+    let report = collect_doctor_report(backend, matches, config_report).await;
 
     if json {
         match serde_json::to_string_pretty(&report) {
@@ -385,6 +453,13 @@ mod tests {
     fn render_human_output_structure() {
         let report = DoctorReport {
             version: "0.2.8".to_string(),
+            config_file: ConfigFileReport {
+                path: "/home/test/.config/typemux-cc/config".to_string(),
+                exists: true,
+                loaded_keys: vec![],
+                skipped_keys: vec![],
+                parse_errors: vec![],
+            },
             configuration: ConfigReport {
                 items: vec![
                     ConfigItem {
@@ -417,6 +492,8 @@ mod tests {
         let output = render_human(&report);
 
         assert!(output.starts_with("typemux-cc v0.2.8\n"));
+        assert!(output.contains("Config file:"));
+        assert!(output.contains("loaded"));
         assert!(output.contains("Configuration:"));
         assert!(output.contains("backend"));
         assert!(output.contains("pyright"));
@@ -432,6 +509,13 @@ mod tests {
     fn render_human_handles_missing_values() {
         let report = DoctorReport {
             version: "0.2.8".to_string(),
+            config_file: ConfigFileReport {
+                path: "/home/test/.config/typemux-cc/config".to_string(),
+                exists: false,
+                loaded_keys: vec![],
+                skipped_keys: vec![],
+                parse_errors: vec![],
+            },
             configuration: ConfigReport { items: vec![] },
             environment: EnvironmentReport {
                 backend_binary: BackendBinaryInfo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod backend;
 mod backend_pool;
+mod config;
 mod doctor;
 mod proxy;
 
@@ -54,11 +55,14 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Load config file BEFORE clap parsing so env vars are available for clap's `env = "..."`
+    let config_report = config::load_config_file();
+
     let matches = Args::command().get_matches();
     let args = Args::from_arg_matches(&matches)?;
 
     if args.doctor {
-        doctor::run_doctor(&args.backend, args.json, &matches).await;
+        doctor::run_doctor(&args.backend, args.json, &matches, &config_report).await;
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

- Add native config file loading (`~/.config/typemux-cc/config`) directly in the binary, eliminating dependency on wrapper shell script
- Update `--doctor` to show config file status and accurate per-setting provenance (`cli` / `env` / `config` / `default`)
- Change `plugin.json` to launch binary directly instead of wrapper script
- Rewrite README to reflect plugin-first usage (remove CLI-centric examples, document config file format and priority)

## Motivation

The binary previously had no config file loading — it relied on the wrapper script (`typemux-cc-wrapper.sh`) to `source ~/.config/typemux-cc/config` before launching. This caused several problems:

1. `typemux-cc --doctor` from terminal didn't reflect config settings (wrapper not invoked)
2. Wrapper required `CLAUDE_PLUGIN_ROOT` env var, so it couldn't run outside plugin context
3. Glob paths to wrapper broke with multiple cached versions
4. Two different config interpretation paths (Bash `source` vs Rust `clap env`) created subtle inconsistencies

## Changes

### `src/config.rs` (new)
- Dotenv-compatible parser: `KEY=VALUE`, `export KEY=VALUE`, quote stripping
- Shell expansion explicitly rejected with structured `ParseError`
- Returns `ConfigLoadReport` with provenance tracking (`loaded_keys`, `skipped_keys`, `parse_errors`)
- Existing env vars are never overwritten (priority: env > config)
- Duplicate keys: last wins (dotenv standard)

### `src/main.rs`
- Calls `config::load_config_file()` before clap parsing
- Passes `ConfigLoadReport` to doctor

### `src/doctor.rs`
- New `Config file:` section showing path, status, and parse warnings
- Accurate source labels using provenance from `ConfigLoadReport`
- `warmup_timeout` / `fanout_timeout` provenance also fixed

### `.claude-plugin/plugin.json`
- Changed command from wrapper script to binary directly

### `README.md`
- Removed CLI-centric usage examples
- Documented config file format with `KEY=VALUE` syntax
- Updated `--doctor` examples with plugin cache path
- Added settings priority documentation

## Test plan
- [x] `make all` passes (fmt + lint + 41 unit tests + 5 doctor tests + E2E tests)
- [x] `cargo run --bin typemux-cc -- --doctor` shows config file loaded with correct provenance
- [x] `TYPEMUX_CC_LOG_FILE=/tmp/override.log cargo run --bin typemux-cc -- --doctor` shows env override
- [x] `--doctor --json` outputs valid JSON with `config_file` section