### PR TITLE
fix: use portable env shebang in install and wrapper scripts

### DIFF
--- a/bin/typemux-cc-wrapper.sh
+++ b/bin/typemux-cc-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # typemux-cc wrapper script
 # Loads configuration from ~/.config/typemux-cc/config if it exists
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Claude Plugin Root (from environment variable)


### PR DESCRIPTION
Fixed shebang for nixos/distros with non-standard install locations for shells