### PR TITLE
fix: resolve clippy::collapsible_match warning on Rust 1.95

### DIFF
--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -106,12 +106,10 @@ impl LspProxy {
                             tracing::info!("Received exit notification, terminating proxy");
                             return Ok(());
                         }
-                        _ if msg.is_response() => {
-                            if self.dispatch_client_response(&msg).await? {
-                                continue;
-                            }
-                            // Fall through: not a pending backend request
-                            // (original code fell through to didOpen check etc.)
+                        _ if msg.is_response()
+                            && self.dispatch_client_response(&msg).await? =>
+                        {
+                            continue;
                         }
                         Some("textDocument/didOpen") => {
                             didopen_count += 1;


### PR DESCRIPTION
## Summary
- Fixes CI failure on Rust 1.95 where `clippy::collapsible_match` flags the nested `if` inside the `_ if msg.is_response()` arm in `src/proxy/mod.rs`.
- Collapses the inner `if` into the match guard so the response dispatch fast-path becomes a single guarded arm.
- Drops a misleading `// Fall through:` comment — the original arm did not actually fall through to later arms; the new guarded form makes that fall-through behavior real (when `dispatch_client_response` returns `false`, subsequent arms are now evaluated).

## Why now
The repo is not pinned to a Rust toolchain, so CI follows latest stable. Rust 1.95 promoted this lint and started failing every PR (e.g. #71 was blocked by it despite being unrelated).

## Test plan
- [x] `make all` (fmt + clippy + test) passes locally on rustc 1.95.0
- [ ] CI green on this PR