### PR TITLE
feat: warn when project root is gitignored from session cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,10 @@ rm -rf ~/.claude/plugins/cache/typemux-cc-marketplace/
 > [!Note]
 > If `.venv` didn't exist when a file was first opened, typemux-cc automatically re-searches for it on the next LSP request. No need to reopen the file.
 
+### "Project root is gitignored" Warning
+
+Claude Code's LSP tool filters `goToDefinition`/`findReferences` results through `git check-ignore` run in the session's working directory, silently dropping results whose paths are gitignored there ([anthropics/claude-code#76371](https://github.com/anthropics/claude-code/issues/76371)). When a backend's project root is gitignored from where Claude Code is running (e.g. a project nested inside a `.claude/worktrees/` directory), typemux-cc shows a `window/showMessage` warning so missing results don't look like an LSP failure. Launch Claude Code from inside the project directory to avoid this.
+
 ## Known Limitations
 
 | Item | Limitation | Workaround |

--- a/src/proxy/client_dispatch.rs
+++ b/src/proxy/client_dispatch.rs
@@ -44,11 +44,13 @@ impl super::LspProxy {
                     let parts = backend.into_split();
                     let tx = self.state.pool.msg_sender();
                     let instance = BackendInstance::from_parts(parts, venv.clone(), session, tx);
-                    self.state.pool.insert(venv, instance);
+                    self.state.pool.insert(venv.clone(), instance);
 
                     // Send initialize response to client
                     client_writer.write_message(&init_response).await?;
                     tracing::info!("Initial backend inserted into pool");
+                    self.warn_if_project_root_ignored(&venv, client_writer)
+                        .await;
                 }
                 Err(e) => {
                     tracing::error!(error = ?e, "Failed to initialize fallback backend, returning minimal response");

--- a/src/proxy/diagnostics.rs
+++ b/src/proxy/diagnostics.rs
@@ -1,9 +1,69 @@
 use crate::error::ProxyError;
 use crate::framing::LspFrameWriter;
 use crate::message::RpcMessage;
+use crate::venv;
 use std::path::Path;
 
 impl super::LspProxy {
+    /// Warn the client if a venv's project root is gitignored from the proxy's cwd.
+    ///
+    /// Claude Code's LSP tool filters goToDefinition/findReferences/etc. results
+    /// through `git check-ignore` run in the session cwd, silently dropping
+    /// locations under gitignored paths (anthropics/claude-code#76371). Checked
+    /// at most once per venv per proxy lifetime.
+    pub(crate) async fn warn_if_project_root_ignored(
+        &mut self,
+        venv_path: &Path,
+        client_writer: &mut LspFrameWriter<tokio::io::Stdout>,
+    ) {
+        if self.state.ignore_checked_venvs.contains(venv_path) {
+            return;
+        }
+        self.state
+            .ignore_checked_venvs
+            .insert(venv_path.to_path_buf());
+
+        let Some(project_root) = venv_path.parent() else {
+            return;
+        };
+
+        let cwd = match std::env::current_dir() {
+            Ok(cwd) => cwd,
+            Err(e) => {
+                tracing::warn!(error = ?e, "Failed to get current directory for gitignore check");
+                return;
+            }
+        };
+
+        if !venv::is_path_git_ignored(project_root, &cwd).await {
+            return;
+        }
+
+        tracing::warn!(
+            venv = %venv_path.display(),
+            project_root = %project_root.display(),
+            "Project root is gitignored from session cwd; Claude Code will silently hide goToDefinition/findReferences results"
+        );
+
+        let msg = RpcMessage::notification(
+            "window/showMessage",
+            Some(serde_json::json!({
+                "type": 2,
+                "message": format!(
+                    "typemux-cc: project root {} is gitignored from the session working directory. Claude Code silently hides goToDefinition/findReferences results for gitignored paths (anthropics/claude-code#76371). Launch Claude Code inside this directory to avoid this.",
+                    project_root.display()
+                )
+            })),
+        );
+
+        if let Err(e) = client_writer.write_message(&msg).await {
+            tracing::warn!(
+                error = ?e,
+                "Failed to send gitignored project root warning to client"
+            );
+        }
+    }
+
     /// Send window/showMessage error to client when backend creation fails
     pub(crate) async fn notify_backend_error(
         &self,

--- a/src/proxy/pool_management.rs
+++ b/src/proxy/pool_management.rs
@@ -61,6 +61,8 @@ impl super::LspProxy {
             .create_backend_instance(&target_venv, client_writer)
             .await?;
         self.state.pool.insert(target_venv.clone(), instance);
+        self.warn_if_project_root_ignored(&target_venv, client_writer)
+            .await;
 
         Ok(Some(target_venv))
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,7 @@
 use crate::backend::BackendKind;
 use crate::backend_pool::BackendPool;
 use crate::message::{RpcId, RpcMessage};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::time::Instant;
@@ -87,6 +87,11 @@ pub struct ProxyState {
 
     /// Pending fan-out requests (keyed by client request ID)
     pub pending_fanouts: HashMap<RpcId, PendingFanout>,
+
+    /// Venvs already checked for a gitignored project root (checked at most
+    /// once per venv per proxy lifetime, even if the backend is later
+    /// TTL-evicted and respawned).
+    pub ignore_checked_venvs: HashSet<PathBuf>,
 }
 
 impl ProxyState {
@@ -105,6 +110,7 @@ impl ProxyState {
             next_proxy_request_id: -1, // Use negative IDs to avoid collision with client IDs
             pool: BackendPool::new(max_backends, backend_ttl),
             pending_fanouts: HashMap::new(),
+            ignore_checked_venvs: HashSet::new(),
         }
     }
 

--- a/src/venv.rs
+++ b/src/venv.rs
@@ -31,6 +31,34 @@ pub async fn get_git_toplevel(working_dir: &Path) -> Result<Option<PathBuf>, Ven
     }
 }
 
+/// Execute git check-ignore -q <path> and check whether it is gitignored from cwd
+///
+/// Clears GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE so the check always resolves
+/// against `cwd` as requested, instead of silently deferring to an ambient
+/// repository override (e.g. when the proxy is launched from inside a
+/// git hook environment).
+pub async fn is_path_git_ignored(path: &Path, cwd: &Path) -> bool {
+    let output = match Command::new("git")
+        .arg("check-ignore")
+        .arg("-q")
+        .arg(path)
+        .current_dir(cwd)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .await
+    {
+        Ok(output) => output,
+        Err(e) => {
+            tracing::warn!(error = ?e, "git command failed (git not installed or not executable), treating path as not ignored");
+            return false;
+        }
+    };
+
+    output.status.success()
+}
+
 /// Search for .venv by traversing parent directories from file path
 ///
 /// # Arguments
@@ -186,5 +214,58 @@ mod tests {
 
         let result = find_venv(&file, None).await.unwrap();
         assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn test_is_path_git_ignored_matches_gitignore() {
+        // Canonicalize to resolve symlinks (e.g., /var → /private/var on macOS).
+        let temp = tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        std::process::Command::new("git")
+            .arg("init")
+            .current_dir(&root)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .output()
+            .unwrap();
+        fs::write(root.join(".gitignore"), "ignored-dir/\n")
+            .await
+            .unwrap();
+        let ignored_dir = root.join("ignored-dir");
+        fs::create_dir(&ignored_dir).await.unwrap();
+
+        assert!(is_path_git_ignored(&ignored_dir, &root).await);
+    }
+
+    #[tokio::test]
+    async fn test_is_path_git_ignored_not_matched() {
+        let temp = tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        std::process::Command::new("git")
+            .arg("init")
+            .current_dir(&root)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .output()
+            .unwrap();
+        fs::write(root.join(".gitignore"), "ignored-dir/\n")
+            .await
+            .unwrap();
+        let other_dir = root.join("other-dir");
+        fs::create_dir(&other_dir).await.unwrap();
+
+        assert!(!is_path_git_ignored(&other_dir, &root).await);
+    }
+
+    #[tokio::test]
+    async fn test_is_path_git_ignored_no_git_repo() {
+        let temp = tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let some_dir = root.join("some-dir");
+        fs::create_dir(&some_dir).await.unwrap();
+
+        assert!(!is_path_git_ignored(&some_dir, &root).await);
     }
 }

--- a/tests/gitignore_warning_test.rs
+++ b/tests/gitignore_warning_test.rs
@@ -1,0 +1,129 @@
+mod support;
+
+use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
+
+/// E2E: warn the client when a venv's project root is gitignored from the
+/// proxy's cwd. Claude Code's LSP tool filters goToDefinition/findReferences
+/// results through `git check-ignore` run in the session cwd, silently
+/// dropping gitignored locations (anthropics/claude-code#76371).
+///
+/// Workspace: `pkg/` has `.venv`, and the workspace root's `.gitignore`
+/// excludes `pkg/`. The proxy is started with cwd = workspace root (not
+/// `pkg/`), so the fallback venv is not found and the backend for `pkg`
+/// spawns lazily on the first `didOpen`.
+#[tokio::test]
+async fn warns_when_project_root_is_gitignored() {
+    let scenario = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            // restore_documents_to_backend replays didOpen for a.py (opened before the backend spawned).
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            // Second didOpen for b.py is forwarded directly (backend already in pool).
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover on b.py" } } }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![PackageConfig {
+            name: "pkg".to_string(),
+            scenario,
+            has_venv: true,
+        }],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+
+    // Turn the fixture's minimal `.git` into a real repository and gitignore `pkg/`.
+    std::process::Command::new("git")
+        .arg("init")
+        .current_dir(&root)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .expect("failed to run git init");
+    std::fs::write(root.join(".gitignore"), "pkg/\n").unwrap();
+
+    // Start the proxy from the workspace root (no `.venv` there) so no
+    // fallback backend is pre-spawned; the `pkg` backend spawns on didOpen.
+    let mut proxy = ProxyUnderTest::spawn(temp_dir, root.clone(), &root);
+
+    let root_uri = support::path_to_uri(&root);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    // didOpen a.py under pkg/ → proxy lazily spawns the backend for pkg/.venv.
+    let file_a = root.join("pkg/a.py");
+    std::fs::write(&file_a, "a = 1\n").unwrap();
+    let file_a_uri = support::path_to_uri(&file_a);
+    proxy.did_open(&file_a_uri, "a = 1\n").await;
+
+    // The proxy must warn that pkg/'s project root is gitignored from its cwd.
+    let warning = proxy
+        .wait_for_notification("window/showMessage", 5000)
+        .await;
+    let params = warning.params.expect("window/showMessage must have params");
+    assert_eq!(params["type"], 2, "expected Warning severity");
+    let message = params["message"]
+        .as_str()
+        .expect("message field must be a string");
+    assert!(
+        message.contains("gitignored"),
+        "expected warning message to mention 'gitignored', got: {message}"
+    );
+    assert!(
+        message.contains(&root.join("pkg").display().to_string()),
+        "expected warning message to mention the project root, got: {message}"
+    );
+
+    // didOpen b.py under the same venv must not trigger a duplicate warning.
+    let file_b = root.join("pkg/b.py");
+    std::fs::write(&file_b, "b = 2\n").unwrap();
+    let file_b_uri = support::path_to_uri(&file_b);
+    proxy.did_open(&file_b_uri, "b = 2\n").await;
+
+    let (hover_resp, notifications) = proxy
+        .request_collecting(
+            "textDocument/hover",
+            serde_json::json!({
+                "textDocument": { "uri": &file_b_uri },
+                "position": { "line": 0, "character": 0 }
+            }),
+        )
+        .await;
+    assert!(
+        hover_resp.error.is_none(),
+        "hover on b.py should succeed, got error: {:?}",
+        hover_resp.error
+    );
+    assert!(
+        !notifications
+            .iter()
+            .any(|n| n.method.as_deref() == Some("window/showMessage")),
+        "gitignored project root warning must not be sent twice for the same venv"
+    );
+
+    // Shutdown
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -193,6 +193,33 @@ impl ProxyUnderTest {
         }
     }
 
+    /// Send a request and wait for the response, collecting any notifications
+    /// observed in the meantime (with timeout).
+    #[allow(dead_code)] // Used by some but not all integration test binaries.
+    pub async fn request_collecting(
+        &mut self,
+        method: &str,
+        params: Value,
+    ) -> (RpcMessage, Vec<RpcMessage>) {
+        let id = self.next_id;
+        self.next_id += 1;
+        let msg = RpcMessage::request(RpcId::Number(id), method, Some(params));
+        self.write(&msg).await;
+        let mut notifications = Vec::new();
+        loop {
+            let resp = self.read_next().await;
+            if resp.is_response() {
+                if let Some(RpcId::Number(resp_id)) = &resp.id {
+                    if *resp_id == id {
+                        return (resp, notifications);
+                    }
+                }
+            } else {
+                notifications.push(resp);
+            }
+        }
+    }
+
     /// Perform shutdown + exit sequence. Returns the shutdown response.
     pub async fn shutdown_and_exit(&mut self) -> RpcMessage {
         let resp = self.request("shutdown", Value::Null).await;
@@ -254,6 +281,35 @@ impl ProxyUnderTest {
             }
         }
         collected
+    }
+
+    /// Wait for a notification with the given method, discarding any other
+    /// notifications observed in the meantime. Panics on timeout.
+    #[allow(dead_code)] // Used by some but not all integration test binaries.
+    pub async fn wait_for_notification(&mut self, method: &str, timeout_ms: u64) -> RpcMessage {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                panic!(
+                    "wait_for_notification: timed out after {timeout_ms}ms waiting for {method:?}"
+                );
+            }
+            match tokio::time::timeout(remaining, self.reader.read_message()).await {
+                Ok(Ok(msg)) if msg.method.as_deref() == Some(method) => return msg,
+                Ok(Ok(_)) => continue, // Not the notification we're waiting for.
+                Ok(Err(e)) => {
+                    let stderr = self.dump_stderr().await;
+                    panic!("wait_for_notification: read error: {e}\n--- stderr ---\n{stderr}");
+                }
+                Err(_) => {
+                    let stderr = self.dump_stderr().await;
+                    panic!(
+                        "wait_for_notification: timed out after {timeout_ms}ms waiting for {method:?}\n--- stderr ---\n{stderr}"
+                    );
+                }
+            }
+        }
     }
 
     /// Read the next LSP message (with timeout).


### PR DESCRIPTION
## Summary

- Implements a proactive warning for the root cause documented in #80 and [anthropics/claude-code#76371](https://github.com/anthropics/claude-code/issues/76371): Claude Code's LSP tool silently drops `goToDefinition`/`findReferences` results whose paths are gitignored from the session's cwd, including projects nested under its own `.claude/worktrees/`.
- typemux-cc now detects this at backend spawn time and sends a `window/showMessage` warning, so results hidden by Claude Code don't look like a proxy/LSP failure — aligned with the project's "A Silently Lying LSP Is the Worst" principle.

## Changes

- `src/venv.rs`: new `is_path_git_ignored(path, cwd)` running `git check-ignore -q`, with `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` cleared so an ambient git-hook environment can't override the `cwd` the caller asked for (found and verified empirically) + 3 unit tests.
- `src/state.rs`: `ignore_checked_venvs: HashSet<PathBuf>` so the check runs at most once per venv per proxy lifetime (no re-warn after TTL evict/respawn).
- `src/proxy/diagnostics.rs`: `warn_if_project_root_ignored` sending a `window/showMessage` (type 2) with a link to the upstream issue.
- Call sites: `dispatch_initialize` (initial backend, `src/proxy/client_dispatch.rs`) and `ensure_backend_in_pool` (on-demand backends, `src/proxy/pool_management.rs`).
- `tests/gitignore_warning_test.rs`: E2E test asserting the warning fires for a gitignored project root and is not duplicated for a second file in the same venv.
- `tests/support/mod.rs`: new `wait_for_notification` and `request_collecting` harness helpers.
- `README.md`: Troubleshooting section note.

## Test plan

- [x] `make all` (fmt + clippy `-D warnings` + full test suite) passes