### PR TITLE
chore: strengthen clippy and rustdoc lint configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,90 @@ version = "0.2.11"
 edition = "2021"
 rust-version = "1.75"
 
+[lints.rust]
+warnings = "deny"
+future_incompatible = { level = "deny", priority = -1 }
+nonstandard_style = { level = "deny", priority = -1 }
+rust_2018_idioms = { level = "deny", priority = -1 }
+rust_2024_compatibility = { level = "deny", priority = -1 }
+unsafe_code = "deny"
+
+# The dependency list in this file is shared by the library, a second helper
+# binary, and several integration-test crates, each of which only exercises a
+# subset of it directly. Flagging a dependency as unused in any one target is
+# expected noise, not a signal that it can be removed.
+unused_crate_dependencies = "allow"
+
+# The library target isn't published or consumed outside this crate's own
+# binaries and tests. Narrowing every `pub` item to its minimal visibility is
+# a worthwhile follow-up, but is large enough to be its own pass rather than
+# part of tightening the lint baseline.
+unreachable_pub = "allow"
+
+[lints.rustdoc]
+bare_urls = "deny"
+broken_intra_doc_links = "deny"
+invalid_codeblock_attributes = "deny"
+invalid_html_tags = "deny"
+invalid_rust_codeblocks = "deny"
+missing_crate_level_docs = "deny"
+private_intra_doc_links = "deny"
+redundant_explicit_links = "deny"
+unescaped_backticks = "deny"
+
+[lints.clippy]
+cargo = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
+pedantic = { level = "deny", priority = -1 }
+
+# This crate is not published and has no external consumers, so registry
+# metadata completeness and cross-target dependency-version duplication
+# don't affect anything that matters here.
+cargo_common_metadata = "allow"
+multiple_crate_versions = "allow"
+
+# `pedantic` and `nursery` catch real issues but also bundle in style
+# preferences that don't match this codebase. Enable the groups, then allow
+# the specific lints that conflict with existing conventions, so the
+# remaining denies stay meaningful instead of the group being blanket-ignored.
+manual_let_else = "allow"
+missing_errors_doc = "allow"
+missing_const_for_fn = "allow"
+must_use_candidate = "allow"
+redundant_pub_crate = "allow"
+ref_option = "allow"
+significant_drop_in_scrutinee = "allow"
+significant_drop_tightening = "allow"
+too_many_lines = "allow"
+uninlined_format_args = "allow"
+unreadable_literal = "allow"
+use_self = "allow"
+
+# This proxy does frequent offset/length arithmetic between `u64` (the LSP
+# wire format) and `usize` (Rust indexing). Rewriting every such cast to
+# satisfy this lint would touch call sites without changing behavior.
+cast_possible_truncation = "allow"
+cast_possible_wrap = "allow"
+
+# Documenting every private item is a worthwhile follow-up, but is large
+# enough to be its own pass rather than part of tightening the lint baseline.
+missing_docs_in_private_items = "allow"
+
+dbg_macro = "deny"
+doc_markdown = "deny"
+missing_panics_doc = "deny"
+todo = "deny"
+unimplemented = "deny"
+
+# This is a CLI tool: writing to stdout/stderr is how it reports results and
+# diagnostics to the user, not a debugging leftover.
+print_stdout = "allow"
+print_stderr = "allow"
+
+# `panic!` currently appears only in test-support helpers (assertion-style
+# failures on bad test setup), never on a production code path.
+panic = "allow"
+
 [dependencies]
 tokio = { version = "1.43", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: all check fmt lint test build clean
+.PHONY: all check fmt lint doc test build clean
 
 # Default target: run all
-all: fmt lint test
+all: fmt lint doc test
 
 # Format
 fmt:
@@ -11,9 +11,13 @@ fmt:
 fmt-check:
 	cargo fmt --check
 
-# Lint (clippy)
+# Lint (clippy, including test/bin targets)
 lint:
-	cargo clippy -- -D warnings
+	cargo clippy --workspace --all-targets --locked -- -D warnings
+
+# Doc (rustdoc lints; matches [lints.rustdoc] in Cargo.toml)
+doc:
+	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --lib --no-deps --locked
 
 # Test
 test:
@@ -35,5 +39,5 @@ check:
 clean:
 	cargo clean
 
-# For CI: fmt-check + lint + test
-ci: fmt-check lint test
+# For CI: fmt-check + lint + doc + test
+ci: fmt-check lint doc test

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -16,7 +16,7 @@ pub enum BackendKind {
 
 impl BackendKind {
     /// Short name for logging (matches CLI value)
-    pub fn display_name(&self) -> &'static str {
+    pub fn display_name(self) -> &'static str {
         match self {
             Self::Pyright => "pyright",
             Self::Ty => "ty",
@@ -24,7 +24,7 @@ impl BackendKind {
         }
     }
 
-    pub fn command(&self) -> &'static str {
+    pub fn command(self) -> &'static str {
         match self {
             Self::Pyright => "pyright-langserver",
             Self::Ty => "ty",
@@ -34,7 +34,7 @@ impl BackendKind {
 
     /// Command name used for `--version` detection.
     /// pyright-langserver does not support `--version`, so we use `pyright` instead.
-    pub fn version_command(&self) -> &'static str {
+    pub fn version_command(self) -> &'static str {
         match self {
             Self::Pyright => "pyright",
             Self::Ty => "ty",
@@ -42,7 +42,7 @@ impl BackendKind {
         }
     }
 
-    fn args(&self) -> &'static [&'static str] {
+    fn args(self) -> &'static [&'static str] {
         match self {
             Self::Pyright => &["--stdio"],
             Self::Ty => &["server"],
@@ -51,9 +51,10 @@ impl BackendKind {
     }
 
     /// Apply backend-specific environment variables to the command.
-    /// Currently all backends use VIRTUAL_ENV + PATH, but this method
+    /// Currently all backends use `VIRTUAL_ENV` + PATH, but this method
     /// provides the extension point for future backend-specific env setup.
-    pub fn apply_env(&self, cmd: &mut Command, venv: &Path) {
+    #[allow(clippy::unused_self)] // Intentional extension point; see doc comment above.
+    pub fn apply_env(self, cmd: &mut Command, venv: &Path) {
         let venv_str = venv.to_string_lossy();
         cmd.env("VIRTUAL_ENV", venv_str.as_ref());
 
@@ -87,8 +88,8 @@ pub struct LspBackend {
 impl LspBackend {
     /// Spawn an LSP backend process.
     ///
-    /// When venv_path is Some, apply backend-specific environment variables.
-    pub async fn spawn(kind: BackendKind, venv_path: Option<&Path>) -> Result<Self, BackendError> {
+    /// When `venv_path` is Some, apply backend-specific environment variables.
+    pub fn spawn(kind: BackendKind, venv_path: Option<&Path>) -> Result<Self, BackendError> {
         let mut cmd = Command::new(kind.command());
         for arg in kind.args() {
             cmd.arg(arg);

--- a/src/backend_pool.rs
+++ b/src/backend_pool.rs
@@ -29,8 +29,7 @@ pub fn warmup_timeout() -> Duration {
     std::env::var("TYPEMUX_CC_WARMUP_TIMEOUT")
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
-        .map(Duration::from_secs)
-        .unwrap_or(DEFAULT_WARMUP_TIMEOUT)
+        .map_or(DEFAULT_WARMUP_TIMEOUT, Duration::from_secs)
 }
 
 /// Default fan-out timeout; overridable via `TYPEMUX_CC_FANOUT_TIMEOUT` env var.
@@ -42,8 +41,7 @@ pub fn fanout_timeout() -> Duration {
     std::env::var("TYPEMUX_CC_FANOUT_TIMEOUT")
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
-        .map(Duration::from_secs)
-        .unwrap_or(DEFAULT_FANOUT_TIMEOUT)
+        .map_or(DEFAULT_FANOUT_TIMEOUT, Duration::from_secs)
 }
 
 /// Message from a backend reader task
@@ -232,8 +230,8 @@ impl BackendPool {
         self.max_backends
     }
 
-    /// Return venv paths of backends whose last_used exceeds the TTL.
-    /// Only checks TTL/last_used; pending request filtering is the caller's responsibility.
+    /// Return venv paths of backends whose `last_used` exceeds the TTL.
+    /// Only checks `TTL/last_used`; pending request filtering is the caller's responsibility.
     pub fn expired_venvs(&self) -> Vec<PathBuf> {
         let ttl = match self.backend_ttl {
             Some(ttl) => ttl,

--- a/src/bin/mock-lsp-backend.rs
+++ b/src/bin/mock-lsp-backend.rs
@@ -126,6 +126,9 @@ async fn main() {
 
 fn load_scenario() -> Scenario {
     // Try inline JSON first, then file path.
+    // A `map_or_else` rewrite here would nest an if/else inside a closure for no
+    // readability gain over this plain three-way if/else-if/else.
+    #[allow(clippy::option_if_let_else)]
     let json = if let Ok(s) = std::env::var("MOCK_LSP_SCENARIO") {
         s
     } else if let Ok(path) = std::env::var("MOCK_LSP_SCENARIO_FILE") {

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,6 +134,7 @@ pub fn load_config_file() -> ConfigLoadReport {
             skipped_keys.push(key);
         } else {
             // SAFETY: called before any threads are spawned (before tokio runtime)
+            #[allow(unsafe_code)]
             unsafe {
                 std::env::set_var(&key, &value);
             }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -5,6 +5,7 @@ use crate::venv;
 use clap::parser::ValueSource;
 use clap::ArgMatches;
 use serde::Serialize;
+use std::fmt::Write as _;
 use std::path::PathBuf;
 
 /// Top-level doctor report.
@@ -71,7 +72,6 @@ fn arg_source(matches: &ArgMatches, id: &str, config_report: &ConfigLoadReport) 
                 format!("env: {}", env_name)
             }
         }
-        Some(ValueSource::DefaultValue) => "default".to_string(),
         _ => "default".to_string(),
     }
 }
@@ -100,7 +100,7 @@ fn env_only_source(env_var: &str, config_report: &ConfigLoadReport) -> String {
     }
 }
 
-/// Search for a binary in PATH directories using std::env::split_paths + metadata.
+/// Search for a binary in PATH directories using `std::env::split_paths` + metadata.
 /// Returns the first match that is a file with execute permission.
 pub fn find_binary_in_path(binary_name: &str) -> Option<PathBuf> {
     let path_var = std::env::var_os("PATH")?;
@@ -163,7 +163,7 @@ async fn detect_backend_version(command: &str) -> Option<String> {
     }
 }
 
-/// Collect all diagnostic information into a DoctorReport.
+/// Collect all diagnostic information into a `DoctorReport`.
 pub async fn collect_doctor_report(
     backend: &BackendKind,
     matches: &ArgMatches,
@@ -193,8 +193,7 @@ pub async fn collect_doctor_report(
 
     let max_backends_value: String = matches
         .get_one::<u64>("max_backends")
-        .map(|v| v.to_string())
-        .unwrap_or_else(|| "8".to_string());
+        .map_or_else(|| "8".to_string(), std::string::ToString::to_string);
     let max_backends_item = ConfigItem {
         name: "max_backends".to_string(),
         value: max_backends_value,
@@ -203,8 +202,7 @@ pub async fn collect_doctor_report(
 
     let backend_ttl_value: String = matches
         .get_one::<u64>("backend_ttl")
-        .map(|v| v.to_string())
-        .unwrap_or_else(|| "1800".to_string());
+        .map_or_else(|| "1800".to_string(), std::string::ToString::to_string);
     let backend_ttl_item = ConfigItem {
         name: "backend_ttl".to_string(),
         value: backend_ttl_value,
@@ -227,8 +225,7 @@ pub async fn collect_doctor_report(
 
     let log_file_value: String = matches
         .get_one::<PathBuf>("log_file")
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|| "<not set>".to_string());
+        .map_or_else(|| "<not set>".to_string(), |p| p.display().to_string());
     let log_file_source = if matches.value_source("log_file") == Some(ValueSource::DefaultValue)
         || matches.value_source("log_file").is_none()
     {
@@ -295,10 +292,19 @@ fn os_version() -> String {
     #[cfg(unix)]
     {
         let mut utsname = std::mem::MaybeUninit::<libc::utsname>::uninit();
+        // SAFETY: `utsname.as_mut_ptr()` points to valid, writable memory sized
+        // for `libc::utsname`; `uname` only writes into it.
+        #[allow(unsafe_code)]
         let ret = unsafe { libc::uname(utsname.as_mut_ptr()) };
         if ret == 0 {
+            // SAFETY: `ret == 0` confirms `uname` fully initialized `utsname`.
+            #[allow(unsafe_code)]
             let utsname = unsafe { utsname.assume_init() };
+            // SAFETY: `sysname`/`release` are nul-terminated C strings written
+            // by the successful `uname` call above, valid for `utsname`'s scope.
+            #[allow(unsafe_code)]
             let sysname = unsafe { std::ffi::CStr::from_ptr(utsname.sysname.as_ptr()) };
+            #[allow(unsafe_code)]
             let release = unsafe { std::ffi::CStr::from_ptr(utsname.release.as_ptr()) };
             return format!(
                 "{} {}",
@@ -314,26 +320,24 @@ fn os_version() -> String {
 pub fn render_human(report: &DoctorReport) -> String {
     let mut out = String::new();
 
-    out.push_str(&format!("typemux-cc v{}\n", report.version));
+    let _ = writeln!(out, "typemux-cc v{}", report.version);
 
     // Config file info
     out.push_str("\nConfig file:\n");
-    out.push_str(&format!(
-        "  Path              {}\n",
-        report.config_file.path
-    ));
-    out.push_str(&format!(
-        "  Status            {}\n",
+    let _ = writeln!(out, "  Path              {}", report.config_file.path);
+    let _ = writeln!(
+        out,
+        "  Status            {}",
         if report.config_file.exists {
             "loaded"
         } else {
             "not found"
         }
-    ));
+    );
     if !report.config_file.parse_errors.is_empty() {
         out.push_str("  Warnings:\n");
         for err in &report.config_file.parse_errors {
-            out.push_str(&format!("    ⚠ {}\n", err));
+            let _ = writeln!(out, "    ⚠ {err}");
         }
     }
 
@@ -356,59 +360,61 @@ pub fn render_human(report: &DoctorReport) -> String {
         .unwrap_or(0);
 
     for item in &report.configuration.items {
-        out.push_str(&format!(
-            "  {:<kw$}  {:<vw$}  ({})\n",
-            item.name,
-            item.value,
-            item.source,
-            kw = max_key,
-            vw = max_val,
-        ));
+        let _ = writeln!(
+            out,
+            "  {:<max_key$}  {:<max_val$}  ({})",
+            item.name, item.value, item.source,
+        );
     }
 
     out.push_str("\nEnvironment:\n");
-    out.push_str(&format!(
-        "  Backend binary    {}\n",
+    let _ = writeln!(
+        out,
+        "  Backend binary    {}",
         report.environment.backend_binary.command
-    ));
-    out.push_str(&format!(
-        "    Path            {}\n",
+    );
+    let _ = writeln!(
+        out,
+        "    Path            {}",
         report
             .environment
             .backend_binary
             .path
             .as_deref()
             .unwrap_or("<not found>")
-    ));
-    out.push_str(&format!(
-        "    Version         {}\n",
+    );
+    let _ = writeln!(
+        out,
+        "    Version         {}",
         report
             .environment
             .backend_binary
             .version
             .as_deref()
             .unwrap_or("<unknown>")
-    ));
-    out.push_str(&format!(
-        "  Git toplevel      {}\n",
+    );
+    let _ = writeln!(
+        out,
+        "  Git toplevel      {}",
         report
             .environment
             .git_toplevel
             .as_deref()
             .unwrap_or("<not in a git repo>")
-    ));
-    out.push_str(&format!(
-        "  Fallback venv     {}\n",
+    );
+    let _ = writeln!(
+        out,
+        "  Fallback venv     {}",
         report
             .environment
             .fallback_venv
             .as_deref()
             .unwrap_or("<not found>")
-    ));
+    );
 
     out.push_str("\nSystem:\n");
-    out.push_str(&format!("  OS                {}\n", report.system.os));
-    out.push_str(&format!("  Arch              {}\n", report.system.arch));
+    let _ = writeln!(out, "  OS                {}", report.system.os);
+    let _ = writeln!(out, "  Arch              {}", report.system.arch);
 
     out
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+//! LSP wire-protocol plumbing shared between the `typemux-cc` binary and its
+//! integration test harness: message framing ([`framing`]), the JSON-RPC
+//! message type ([`message`]), and error types ([`error`]). The rest of the
+//! proxy (backend management, request dispatch, CLI) lives in binary-only
+//! modules declared directly in `main.rs`, not re-exported here.
+
 pub mod error;
 pub mod framing;
 pub mod message;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,22 +20,22 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// Optional path to log file (default: stderr only)
-    /// Can also be set via TYPEMUX_CC_LOG_FILE environment variable
+    /// Can also be set via `TYPEMUX_CC_LOG_FILE` environment variable
     #[arg(long, env = "TYPEMUX_CC_LOG_FILE")]
     log_file: Option<PathBuf>,
 
     /// Maximum number of concurrent backend processes (default: 8, minimum: 1)
-    /// Can also be set via TYPEMUX_CC_MAX_BACKENDS environment variable
+    /// Can also be set via `TYPEMUX_CC_MAX_BACKENDS` environment variable
     #[arg(long, env = "TYPEMUX_CC_MAX_BACKENDS", default_value = "8", value_parser = clap::value_parser!(u64).range(1..))]
     max_backends: u64,
 
     /// Backend TTL in seconds (default: 1800 = 30 minutes). Set to 0 to disable TTL eviction.
-    /// Can also be set via TYPEMUX_CC_BACKEND_TTL environment variable
+    /// Can also be set via `TYPEMUX_CC_BACKEND_TTL` environment variable
     #[arg(long, env = "TYPEMUX_CC_BACKEND_TTL", default_value = "1800")]
     backend_ttl: u64,
 
     /// LSP backend to use: pyright, ty, or pyrefly
-    /// Can also be set via TYPEMUX_CC_BACKEND environment variable
+    /// Can also be set via `TYPEMUX_CC_BACKEND` environment variable
     #[arg(
         long,
         env = "TYPEMUX_CC_BACKEND",
@@ -71,10 +71,12 @@ async fn main() -> anyhow::Result<()> {
         // File output specified: stderr + file
         let file_appender = RollingFileAppender::new(
             Rotation::NEVER,
-            log_path.parent().unwrap_or(std::path::Path::new(".")),
+            log_path
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new(".")),
             log_path
                 .file_name()
-                .unwrap_or(std::ffi::OsStr::new("typemux-cc.log")),
+                .unwrap_or_else(|| std::ffi::OsStr::new("typemux-cc.log")),
         );
 
         tracing_subscriber::registry()

--- a/src/proxy/client_dispatch.rs
+++ b/src/proxy/client_dispatch.rs
@@ -32,6 +32,10 @@ impl super::LspProxy {
         tracing::info!("Caching initialize message for backend initialization");
         self.state.client_initialize = Some(msg.clone());
 
+        // `backend` holds a child-process handle with a custom `Drop`, so its
+        // scope will change under Edition 2024. Deferred to the eventual edition
+        // migration rather than restructured here to satisfy the lint.
+        #[allow(if_let_rescope)]
         if let Some((mut backend, venv)) = pending_initial_backend.take() {
             // Forward initialize to the pre-spawned backend
             match self
@@ -229,25 +233,21 @@ impl super::LspProxy {
                 target_venv = self.venv_for_uri(&url);
 
                 if target_venv.is_none() {
-                    let file_path = match url.to_file_path() {
-                        Ok(p) => p,
-                        Err(_) => {
-                            // Non-file URI (e.g., untitled:, vscode-notebook-cell:)
-                            tracing::warn!(
-                                method = ?msg.method_name(),
-                                uri = %url,
-                                "Cannot resolve venv for non-file URI"
-                            );
-                            let error_response = RpcMessage::error_response(
-                                msg,
-                                &format!(
-                                    "lsp-proxy: cannot resolve venv for non-file URI: {}",
-                                    url
-                                ),
-                            );
-                            client_writer.write_message(&error_response).await?;
-                            return Ok(());
-                        }
+                    let file_path = if let Ok(p) = url.to_file_path() {
+                        p
+                    } else {
+                        // Non-file URI (e.g., untitled:, vscode-notebook-cell:)
+                        tracing::warn!(
+                            method = ?msg.method_name(),
+                            uri = %url,
+                            "Cannot resolve venv for non-file URI"
+                        );
+                        let error_response = RpcMessage::error_response(
+                            msg,
+                            &format!("lsp-proxy: cannot resolve venv for non-file URI: {}", url),
+                        );
+                        client_writer.write_message(&error_response).await?;
+                        return Ok(());
                     };
 
                     match self
@@ -543,9 +543,8 @@ impl super::LspProxy {
 fn extract_cancel_id(msg: &RpcMessage) -> Option<RpcId> {
     let params = msg.params.as_ref()?;
     let id_value = params.get("id")?;
-    if let Some(n) = id_value.as_i64() {
-        Some(RpcId::Number(n))
-    } else {
-        id_value.as_str().map(|s| RpcId::String(s.to_string()))
-    }
+    id_value.as_i64().map_or_else(
+        || id_value.as_str().map(|s| RpcId::String(s.to_string())),
+        |n| Some(RpcId::Number(n)),
+    )
 }

--- a/src/proxy/diagnostics.rs
+++ b/src/proxy/diagnostics.rs
@@ -140,7 +140,7 @@ impl super::LspProxy {
             );
 
             match client_writer.write_message(&clear_msg).await {
-                Ok(_) => ok += 1,
+                Ok(()) => ok += 1,
                 Err(e) => {
                     failed += 1;
                     tracing::warn!(uri = %uri, error = ?e, "Failed to clear diagnostics");

--- a/src/proxy/document.rs
+++ b/src/proxy/document.rs
@@ -38,7 +38,7 @@ impl super::LspProxy {
         let text = text_document
             .get("text")
             .and_then(|t| t.as_str())
-            .map(|s| s.to_string());
+            .map(std::string::ToString::to_string);
 
         let Some(uri_str) = text_document.get("uri").and_then(|u| u.as_str()) else {
             return Ok(());
@@ -58,7 +58,7 @@ impl super::LspProxy {
 
         let version = text_document
             .get("version")
-            .and_then(|v| v.as_i64())
+            .and_then(serde_json::Value::as_i64)
             .unwrap_or(0) as i32;
 
         tracing::info!(
@@ -69,7 +69,7 @@ impl super::LspProxy {
         );
 
         // Search for .venv
-        let found_venv = venv::find_venv(&file_path, self.state.git_toplevel.as_deref()).await?;
+        let found_venv = venv::find_venv(&file_path, self.state.git_toplevel.as_deref());
 
         // Cache document
         if let Some(text_content) = &text {
@@ -92,6 +92,9 @@ impl super::LspProxy {
         };
 
         if !self.state.pool.contains(venv_path) {
+            // `Some`/`None` both just mean "handled, nothing left to forward here" but
+            // for distinct reasons, so keep them as separate documented arms.
+            #[allow(clippy::match_same_arms)]
             match self
                 .ensure_backend_in_pool(&url, &file_path, client_writer)
                 .await
@@ -113,7 +116,7 @@ impl super::LspProxy {
     }
 
     /// Handle didChange
-    pub(crate) async fn handle_did_change(&mut self, msg: &RpcMessage) -> Result<(), ProxyError> {
+    pub(crate) fn handle_did_change(&mut self, msg: &RpcMessage) -> Result<(), ProxyError> {
         let Some(params) = &msg.params else {
             return Ok(());
         };
@@ -129,7 +132,7 @@ impl super::LspProxy {
 
         let version = text_document
             .get("version")
-            .and_then(|v| v.as_i64())
+            .and_then(serde_json::Value::as_i64)
             .map(|v| v as i32);
 
         let Some(content_changes) = params.get("contentChanges") else {
@@ -180,9 +183,9 @@ impl super::LspProxy {
     }
 
     /// Handle didClose: remove document from cache
-    pub(crate) async fn handle_did_close(&mut self, msg: &RpcMessage) -> Result<(), ProxyError> {
+    pub(crate) fn handle_did_close(&mut self, msg: &RpcMessage) {
         let Some(url) = Self::extract_text_document_uri(msg) else {
-            return Ok(());
+            return;
         };
 
         if self.state.open_documents.remove(&url).is_some() {
@@ -197,7 +200,5 @@ impl super::LspProxy {
                 "didClose for unknown document"
             );
         }
-
-        Ok(())
     }
 }

--- a/src/proxy/fanout.rs
+++ b/src/proxy/fanout.rs
@@ -138,14 +138,14 @@ impl super::LspProxy {
 
         // Remove the sub-request entry
         let fanout = self.state.pending_fanouts.get_mut(&client_id).unwrap();
-        let (_venv_path, _session) = fanout.sub_requests.remove(response_id).unwrap();
+        let (venv_path, _session) = fanout.sub_requests.remove(response_id).unwrap();
 
         // Clean up from pending_requests
         self.state.pending_requests.remove(response_id);
 
         // Process the response
         if msg.error.is_some() {
-            fanout.failed_backends.push(_venv_path);
+            fanout.failed_backends.push(venv_path);
         } else if let Some(result) = &msg.result {
             // workspace/symbol returns an array of SymbolInformation
             if let Some(arr) = result.as_array() {
@@ -306,7 +306,7 @@ impl super::LspProxy {
 
     /// Cancel fan-out sub-requests for a specific backend (venv + session).
     /// Called when a backend crashes or is evicted.
-    /// Returns client_ids of affected fan-outs that need convergence checks.
+    /// Returns `client_ids` of affected fan-outs that need convergence checks.
     pub(crate) fn cancel_fanout_sub_requests(
         &mut self,
         venv_path: &PathBuf,
@@ -314,7 +314,7 @@ impl super::LspProxy {
     ) -> Vec<RpcId> {
         let mut affected_client_ids = Vec::new();
 
-        for (client_id, fanout) in self.state.pending_fanouts.iter_mut() {
+        for (client_id, fanout) in &mut self.state.pending_fanouts {
             let matching_proxy_ids: Vec<RpcId> = fanout
                 .sub_requests
                 .iter()
@@ -367,7 +367,7 @@ pub fn dedupe_symbol_results(results: Vec<serde_json::Value>) -> Vec<serde_json:
     deduped
 }
 
-/// Extract dedup key from a SymbolInformation value.
+/// Extract dedup key from a `SymbolInformation` value.
 fn extract_dedupe_key(item: &serde_json::Value) -> Option<(String, u64, u64, String, u64)> {
     let name = item.get("name")?.as_str()?;
     let kind = item.get("kind")?.as_u64()?;

--- a/src/proxy/initialization.rs
+++ b/src/proxy/initialization.rs
@@ -157,7 +157,7 @@ impl super::LspProxy {
         perform_initialize_handshake(backend, init_params, venv).await
     }
 
-    /// Create a new backend, initialize it, split it, and return a BackendInstance.
+    /// Create a new backend, initialize it, split it, and return a `BackendInstance`.
     /// Does NOT insert into the pool — caller is responsible for that.
     pub(crate) async fn create_backend_instance(
         &mut self,
@@ -173,7 +173,7 @@ impl super::LspProxy {
         );
 
         // 1. Spawn
-        let mut backend = LspBackend::spawn(self.state.backend_kind, Some(venv)).await?;
+        let mut backend = LspBackend::spawn(self.state.backend_kind, Some(venv))?;
 
         // 2. Initialize handshake
         let init_params = self.cached_init_params()?;
@@ -203,7 +203,7 @@ impl super::LspProxy {
         session: u64,
         _client_writer: &mut LspFrameWriter<tokio::io::Stdout>,
     ) -> Result<(), ProxyError> {
-        let venv_parent = venv.parent().map(|p| p.to_path_buf());
+        let venv_parent = venv.parent().map(std::path::Path::to_path_buf);
         let total_docs = self.state.open_documents.len();
         let mut restored = 0;
         let mut skipped = 0;
@@ -248,7 +248,7 @@ impl super::LspProxy {
             );
 
             match backend.send_message(&didopen_msg).await {
-                Ok(_) => {
+                Ok(()) => {
                     restored += 1;
                     tracing::info!(
                         session = session,

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -58,7 +58,7 @@ impl LspProxy {
             fallback_venv
         {
             tracing::info!(venv = %venv.display(), "Using fallback .venv, pre-spawning backend");
-            let backend = LspBackend::spawn(self.state.backend_kind, Some(&venv)).await?;
+            let backend = LspBackend::spawn(self.state.backend_kind, Some(&venv))?;
             Some((backend, venv))
         } else {
             tracing::warn!("No fallback .venv found, starting with empty pool");
@@ -108,15 +108,13 @@ impl LspProxy {
                         }
                         _ if msg.is_response()
                             && self.dispatch_client_response(&msg).await? =>
-                        {
-                            continue;
-                        }
+                        {}
                         Some("textDocument/didOpen") => {
                             didopen_count += 1;
                             self.handle_did_open(&msg, didopen_count, &mut client_writer).await?;
                         }
                         Some("textDocument/didChange") => {
-                            self.handle_did_change(&msg).await?;
+                            self.handle_did_change(&msg)?;
                             // Forward to appropriate backend
                             if let Some(url) = Self::extract_text_document_uri(&msg) {
                                 if let Some(venv_path) = self.venv_for_uri(&url) {
@@ -129,7 +127,7 @@ impl LspProxy {
                             let venv_for_close = Self::extract_text_document_uri(&msg)
                                 .and_then(|url| self.venv_for_uri(&url));
 
-                            self.handle_did_close(&msg).await?;
+                            self.handle_did_close(&msg);
 
                             // Forward to appropriate backend
                             if let Some(venv_path) = venv_for_close {
@@ -160,7 +158,7 @@ impl LspProxy {
                 }
 
                 // Warmup timeout: fail-open transition for warming backends
-                _ = async {
+                () = async {
                     match warmup_deadline {
                         Some(deadline) => tokio::time::sleep_until(deadline).await,
                         None => std::future::pending::<()>().await,
@@ -170,7 +168,7 @@ impl LspProxy {
                 }
 
                 // Fan-out timeout: return partial results for timed-out fan-out requests
-                _ = async {
+                () = async {
                     match fanout_deadline {
                         Some(deadline) => tokio::time::sleep_until(deadline).await,
                         None => std::future::pending::<()>().await,

--- a/src/proxy/pool_management.rs
+++ b/src/proxy/pool_management.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 impl super::LspProxy {
     /// Ensure a backend for the given URI's venv is in the pool.
-    /// Returns Some(venv_path) if a backend is available, None if no venv found.
+    /// Returns `Some(venv_path)` if a backend is available, None if no venv found.
     pub(crate) async fn ensure_backend_in_pool(
         &mut self,
         url: &url::Url,
@@ -26,7 +26,7 @@ impl super::LspProxy {
             Some(None) => {
                 // venv was not found when the document was opened.
                 // Re-search in case .venv was created after didOpen.
-                let found = venv::find_venv(file_path, self.state.git_toplevel.as_deref()).await?;
+                let found = venv::find_venv(file_path, self.state.git_toplevel.as_deref());
                 if let Some(ref venv_path) = found {
                     if let Some(doc) = self.state.open_documents.get_mut(url) {
                         doc.venv = Some(venv_path.clone());
@@ -37,7 +37,7 @@ impl super::LspProxy {
             }
             None => {
                 tracing::debug!(uri = %url, "URI not in cache, searching venv");
-                venv::find_venv(file_path, self.state.git_toplevel.as_deref()).await?
+                venv::find_venv(file_path, self.state.git_toplevel.as_deref())
             }
         };
 
@@ -105,6 +105,12 @@ impl super::LspProxy {
 
     /// Evict all expired backends (TTL-based auto-eviction).
     /// Skips backends that have pending client→backend or backend→client requests.
+    ///
+    /// The removed instance holds a child-process handle with a custom `Drop`,
+    /// so its drop order will change under Edition 2024. Deferred to the
+    /// eventual edition migration rather than restructured here to satisfy
+    /// the lint.
+    #[allow(tail_expr_drop_order)]
     pub(crate) async fn evict_expired_backends(
         &mut self,
         client_writer: &mut LspFrameWriter<tokio::io::Stdout>,
@@ -242,7 +248,7 @@ impl super::LspProxy {
         Ok(())
     }
 
-    /// Cancel pending requests for a specific backend (identified by venv_path + session).
+    /// Cancel pending requests for a specific backend (identified by `venv_path` + session).
     /// Also handles fan-out sub-requests: removes them from pending fanouts and
     /// completes any fanouts that have no remaining sub-requests.
     pub(crate) async fn cancel_pending_requests_for_backend(
@@ -283,7 +289,7 @@ impl super::LspProxy {
         Ok(())
     }
 
-    /// Clean up pending_backend_requests entries for a specific backend
+    /// Clean up `pending_backend_requests` entries for a specific backend
     pub(crate) fn clean_pending_backend_requests(&mut self, venv_path: &PathBuf, session: u64) {
         self.state
             .pending_backend_requests
@@ -304,7 +310,7 @@ impl super::LspProxy {
                 self.state
                     .pool
                     .get(venv)
-                    .is_some_and(|inst| inst.warmup_expired())
+                    .is_some_and(super::super::backend_pool::BackendInstance::warmup_expired)
             })
             .collect();
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -36,7 +36,7 @@ pub struct PendingFanout {
     pub expected_count: usize,
     /// Collected results from successful backends
     pub results: Vec<serde_json::Value>,
-    /// Maps proxy_id → (venv_path, session) for each sub-request
+    /// Maps `proxy_id` → (`venv_path`, session) for each sub-request
     pub sub_requests: HashMap<RpcId, (PathBuf, u64)>,
     /// Deadline for the fan-out (partial results returned after this).
     /// None means no timeout (wait forever).
@@ -75,8 +75,8 @@ pub struct ProxyState {
     /// Pending requests (client → backend)
     pub pending_requests: HashMap<RpcId, PendingRequest>,
 
-    /// Pending backend requests (backend → client, keyed by proxy_id)
-    /// Maps proxy_id → PendingBackendRequest to route client responses back to correct backend
+    /// Pending backend requests (backend → client, keyed by `proxy_id`)
+    /// Maps `proxy_id` → `PendingBackendRequest` to route client responses back to correct backend
     pub pending_backend_requests: HashMap<RpcId, PendingBackendRequest>,
 
     /// Next proxy ID for server→client requests (monotonically increasing to avoid collisions)

--- a/src/text_edit.rs
+++ b/src/text_edit.rs
@@ -15,24 +15,24 @@ pub(crate) fn apply_incremental_change(
 
     let start_line = start
         .get("line")
-        .and_then(|l| l.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .ok_or_else(|| ProxyError::InvalidMessage("didChange start missing line".to_string()))?
         as usize;
     let start_char = start
         .get("character")
-        .and_then(|c| c.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .ok_or_else(|| {
             ProxyError::InvalidMessage("didChange start missing character".to_string())
         })? as usize;
 
     let end_line = end
         .get("line")
-        .and_then(|l| l.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .ok_or_else(|| ProxyError::InvalidMessage("didChange end missing line".to_string()))?
         as usize;
     let end_char = end
         .get("character")
-        .and_then(|c| c.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .ok_or_else(|| ProxyError::InvalidMessage("didChange end missing character".to_string()))?
         as usize;
 
@@ -64,7 +64,7 @@ pub(crate) fn position_to_offset(
     for (idx, ch) in text.char_indices() {
         if ch == '\n' {
             if current_line == line {
-                return find_offset_in_line(text, line_start_offset, idx, character);
+                return Ok(find_offset_in_line(text, line_start_offset, idx, character));
             }
             current_line += 1;
             line_start_offset = idx + 1;
@@ -72,7 +72,12 @@ pub(crate) fn position_to_offset(
     }
 
     if current_line == line {
-        return find_offset_in_line(text, line_start_offset, text.len(), character);
+        return Ok(find_offset_in_line(
+            text,
+            line_start_offset,
+            text.len(),
+            character,
+        ));
     }
 
     Err(ProxyError::InvalidMessage(format!(
@@ -82,23 +87,18 @@ pub(crate) fn position_to_offset(
 }
 
 /// Count UTF-16 code units within line and return byte offset
-fn find_offset_in_line(
-    text: &str,
-    line_start: usize,
-    line_end: usize,
-    character: usize,
-) -> Result<usize, ProxyError> {
+fn find_offset_in_line(text: &str, line_start: usize, line_end: usize, character: usize) -> usize {
     let line_text = &text[line_start..line_end];
     let mut utf16_offset = 0;
 
     for (idx, ch) in line_text.char_indices() {
         if utf16_offset >= character {
-            return Ok(line_start + idx);
+            return line_start + idx;
         }
         utf16_offset += ch.len_utf16();
     }
 
-    Ok(line_end)
+    line_end
 }
 
 #[cfg(test)]

--- a/src/venv.rs
+++ b/src/venv.rs
@@ -31,9 +31,9 @@ pub async fn get_git_toplevel(working_dir: &Path) -> Result<Option<PathBuf>, Ven
     }
 }
 
-/// Execute git check-ignore -q <path> and check whether it is gitignored from cwd
+/// Execute `git check-ignore -q <path>` and check whether it is gitignored from cwd
 ///
-/// Clears GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE so the check always resolves
+/// Clears `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` so the check always resolves
 /// against `cwd` as requested, instead of silently deferring to an ambient
 /// repository override (e.g. when the proxy is launched from inside a
 /// git hook environment).

--- a/src/venv.rs
+++ b/src/venv.rs
@@ -64,10 +64,7 @@ pub async fn is_path_git_ignored(path: &Path, cwd: &Path) -> bool {
 /// # Arguments
 /// * `file_path` - Starting file path
 /// * `git_toplevel` - Search boundary (if None, search up to root)
-pub async fn find_venv(
-    file_path: &Path,
-    git_toplevel: Option<&Path>,
-) -> Result<Option<PathBuf>, VenvError> {
+pub fn find_venv(file_path: &Path, git_toplevel: Option<&Path>) -> Option<PathBuf> {
     tracing::debug!(
         file = %file_path.display(),
         toplevel = ?git_toplevel.map(|p| p.display().to_string()),
@@ -107,7 +104,7 @@ pub async fn find_venv(
                 depth = depth,
                 ".venv found"
             );
-            return Ok(Some(venv_path));
+            return Some(venv_path);
         }
 
         // Move to parent directory
@@ -120,7 +117,7 @@ pub async fn find_venv(
         depth = depth,
         "No .venv found"
     );
-    Ok(None)
+    None
 }
 
 /// Search for fallback env (.venv search from cwd at startup)
@@ -202,7 +199,7 @@ mod tests {
         let file = subdir.join("test.py");
         fs::write(&file, "# test").await.unwrap();
 
-        let result = find_venv(&file, None).await.unwrap();
+        let result = find_venv(&file, None);
         assert_eq!(result, Some(venv));
     }
 
@@ -212,7 +209,7 @@ mod tests {
         let file = temp.path().join("test.py");
         fs::write(&file, "# test").await.unwrap();
 
-        let result = find_venv(&file, None).await.unwrap();
+        let result = find_venv(&file, None);
         assert_eq!(result, None);
     }
 

--- a/tests/crash_recovery_test.rs
+++ b/tests/crash_recovery_test.rs
@@ -8,6 +8,9 @@ use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
 /// 1st lifetime: hover succeeds, then didOpen triggers crash (exit 1)
 /// 2nd lifetime: scenario rewritten on disk, hover succeeds with new backend
 #[tokio::test]
+// `file_a`/`file_b` (and their `_uri` variants) are deliberately parallel names
+// for the two test fixtures this scenario exercises.
+#[allow(clippy::similar_names)]
 async fn backend_crash_recovery() {
     // First lifetime scenario: hover works, then crash on didOpen.
     let scenario_life1 = serde_json::json!({

--- a/tests/gitignore_warning_test.rs
+++ b/tests/gitignore_warning_test.rs
@@ -12,6 +12,9 @@ use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
 /// `pkg/`), so the fallback venv is not found and the backend for `pkg`
 /// spawns lazily on the first `didOpen`.
 #[tokio::test]
+// `file_a`/`file_b` (and their `_uri` variants) are deliberately parallel names
+// for the two test fixtures this scenario exercises.
+#[allow(clippy::similar_names)]
 async fn warns_when_project_root_is_gitignored() {
     let scenario = serde_json::json!({
         "on_startup": [],

--- a/tests/multi_venv_test.rs
+++ b/tests/multi_venv_test.rs
@@ -8,6 +8,9 @@ use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
 /// - proj-b hover → "hover from backend-b"
 /// - proj-a hover again → still "hover from backend-a" (no cross-contamination)
 #[tokio::test]
+// `file_a`/`file_b` (and their `_uri` variants) are deliberately parallel names
+// for the two test fixtures this scenario exercises.
+#[allow(clippy::similar_names)]
 async fn multi_venv_switching() {
     let scenario_a = serde_json::json!({
         "on_startup": [],

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -297,14 +297,13 @@ impl ProxyUnderTest {
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
         loop {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                panic!(
-                    "wait_for_notification: timed out after {timeout_ms}ms waiting for {method:?}"
-                );
-            }
+            assert!(
+                !remaining.is_zero(),
+                "wait_for_notification: timed out after {timeout_ms}ms waiting for {method:?}"
+            );
             match tokio::time::timeout(remaining, self.reader.read_message()).await {
                 Ok(Ok(msg)) if msg.method.as_deref() == Some(method) => return msg,
-                Ok(Ok(_)) => continue, // Not the notification we're waiting for.
+                Ok(Ok(_)) => {} // Not the notification we're waiting for.
                 Ok(Err(e)) => {
                     let stderr = self.dump_stderr().await;
                     panic!("wait_for_notification: read error: {e}\n--- stderr ---\n{stderr}");

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -94,6 +94,7 @@ pub struct ProxyUnderTest {
     writer: LspFrameWriter<tokio::process::ChildStdin>,
     #[allow(dead_code)]
     temp_dir: TempDir,
+    #[allow(dead_code)] // Read via `root()`, used by some but not all integration test binaries.
     root: PathBuf,
     next_id: i64,
 }
@@ -131,6 +132,7 @@ impl ProxyUnderTest {
     }
 
     /// Return the canonical workspace root path.
+    #[allow(dead_code)] // Used by some but not all integration test binaries.
     pub fn root(&self) -> &Path {
         &self.root
     }
@@ -233,6 +235,7 @@ impl ProxyUnderTest {
     /// Reads messages until `expected_diag_count` publishDiagnostics notifications
     /// with empty diagnostics arrays are received, or the absolute deadline expires.
     /// Panics if a non-notification message (response) is received unexpectedly.
+    #[allow(dead_code)] // Used by some but not all integration test binaries.
     pub async fn wait_for_crash_cleanup(
         &mut self,
         expected_diag_count: usize,
@@ -244,12 +247,16 @@ impl ProxyUnderTest {
 
         while diag_count < expected_diag_count {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                panic!(
-                    "wait_for_crash_cleanup: timed out after {}ms, got {}/{} diagnostics",
-                    timeout_ms, diag_count, expected_diag_count
-                );
-            }
+            assert!(
+                !remaining.is_zero(),
+                "wait_for_crash_cleanup: timed out after {}ms, got {}/{} diagnostics",
+                timeout_ms,
+                diag_count,
+                expected_diag_count
+            );
+            // The outer `Err` case is `tokio::time::error::Elapsed`, which carries no
+            // information beyond "timed out" — already covered by the panic message below.
+            #[allow(clippy::match_wild_err_arm)]
             match tokio::time::timeout(remaining, self.reader.read_message()).await {
                 Ok(Ok(msg)) => {
                     assert!(
@@ -260,7 +267,7 @@ impl ProxyUnderTest {
                     if msg.method.as_deref() == Some("textDocument/publishDiagnostics") {
                         if let Some(params) = &msg.params {
                             if let Some(diags) = params.get("diagnostics") {
-                                if diags.as_array().is_some_and(|a| a.is_empty()) {
+                                if diags.as_array().is_some_and(std::vec::Vec::is_empty) {
                                     diag_count += 1;
                                 }
                             }

--- a/tests/venv_detection_test.rs
+++ b/tests/venv_detection_test.rs
@@ -7,6 +7,9 @@ use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
 /// - `pkg-a` has `.venv` → backend auto-spawns on didOpen, hover works
 /// - `pkg-b` has no `.venv` → hover returns error (strict mode, no fallback)
 #[tokio::test]
+// `file_a`/`file_b` (and their `_uri` variants) are deliberately parallel names
+// for the two test fixtures this scenario exercises.
+#[allow(clippy::similar_names)]
 async fn venv_detection_routing() {
     let scenario_a = serde_json::json!({
         "on_startup": [],


### PR DESCRIPTION
## Summary

- Enable `clippy::pedantic`/`nursery`/`cargo` plus additional rustc and rustdoc lint groups via `[lints]` in `Cargo.toml`. Every exception is scoped to the individual lint (not a blanket group allow) and has an inline comment explaining why it conflicts with this crate's shape: a CLI binary with real FFI (`uname`, `set_var`), intentional stdout/stderr output, and no external library consumers.
- Fix the ~170 warnings the new config surfaces. Most are mechanical (`write!`-based string building instead of `push_str(&format!(...))`, Copy-by-value methods on `BackendKind`, dropped needless `Result`/`async` wrappers, backtick-wrapped identifiers in doc comments). A handful of `unsafe` blocks get `#[allow(unsafe_code)]` with a `SAFETY` comment instead of a blanket `forbid`, since this crate does use FFI legitimately.
- Update `make lint`/`make ci` to run clippy across `--all-targets` (this also caught a pre-existing unused-method warning in the test harness that the old `make lint` invocation didn't see) and add a `make doc` target so `[lints.rustdoc]` is actually enforced.

## Not in scope (candidates for follow-up)

- Backfilling `missing_docs` / `missing_docs_in_private_items` (currently allowed; ~200 items would need doc comments)
- Tightening `unreachable_pub` to `pub(crate)` where possible (currently allowed; ~200 call sites, and needs care since `--fix` can't see what the integration tests and second binary actually use)
- Adding `unwrap_used`/`expect_used`/`indexing_slicing` as a second, production-only clippy pass (only ~7 call sites currently, so this would be a small follow-up)
- `cargo-deny` for dependency advisories/sources — a different tool/category from lints, would need its own `deny.toml`

## Notes for the reviewer

- `VenvError` is never actually constructed by any of the three functions that return it in `src/venv.rs` — worth a look independent of this PR.
- The `#[allow(tail_expr_drop_order)]` / `#[allow(if_let_rescope)]` lint names (Edition 2024 migration lints) are newer than the declared `rust-version = "1.75"`; CI builds with stable so it stays green, but a strict 1.75 toolchain would likely reject them as unknown lints.

## Test plan

- [x] `make all` (fmt + lint + doc + test) passes
- [x] `make ci` (fmt-check + lint + doc + test) passes
- [x] All existing unit and integration tests pass with unchanged behavior
