### PR TITLE
chore: bump version to 0.2.12

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "typemux-cc",
       "source": "./",
       "description": "Python type-checker LSP multiplexer for Claude Code (pyright, ty, pyrefly)",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "homepage": "https://github.com/K-dash/typemux-cc",
       "repository": "https://github.com/K-dash/typemux-cc",
       "strict": false

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typemux-cc",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Python type-checker LSP multiplexer for Claude Code (pyright, ty, pyrefly)",
   "author": {
     "name": "K-dash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "typemux-cc"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typemux-cc"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 rust-version = "1.75"
 


### PR DESCRIPTION
## Summary

- Release bump to ship the gitignored-project-root warning feature (#81) and the corresponding root-cause documentation (#80).
- Follows the format of previous bump commits (e.g. 699f72e for 0.2.11).
- After merge, tagging `v0.2.12` will trigger `release.yml` to build and publish the release binaries.

## Changes

- `Cargo.toml` / `Cargo.lock`: version `0.2.11` → `0.2.12`
- `.claude-plugin/plugin.json`: version `0.2.11` → `0.2.12`
- `.claude-plugin/marketplace.json`: version `0.2.11` → `0.2.12`

## Test plan

- [x] Version field matches across all 3 required locations (`Cargo.toml`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`) and `Cargo.lock` is regenerated accordingly