### PR TITLE
feat: detect replaced or deleted venv and restart backend

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -206,9 +206,53 @@ Strict Venv Mode implements this philosophy.
 
 ### Cache Limitation (Important)
 
-When a document is already cached, its venv is not re-searched on request.
-This means creating `.venv` **after** opening a file will not take effect for that file
-until it is reopened (or the document cache is refreshed).
+Two distinct caches can go stale, and they fail differently:
+
+1. **Document venv cache** (`open_documents[uri].venv`): resolved at `didOpen`.
+   If no venv existed then (`venv: None`), it **is** re-searched on the next
+   URI-bearing request, so a late-created `.venv` is picked up without
+   reopening the file. A cached `Some(venv)` is trusted as long as the venv's
+   identity is unchanged.
+2. **Backend pool identity** (`pool[venv_path]`): keyed by path only. Without
+   identity tracking (below), a backend would keep serving after its `.venv`
+   was replaced or deleted — the "silently lying LSP" failure mode.
+
+## Venv Identity Tracking
+
+### Problem
+
+`uv sync` deletes and recreates `.venv`. The pool key (the venv *path*) is
+unchanged, so without an identity check the old backend — indexed against the
+old environment — keeps answering. Per the design principles, this is the
+worst possible failure mode: results look plausible and are wrong.
+
+### Identity Token
+
+Each backend captures a `VenvToken` at spawn: `dev`/`ino`/`mtime`/`size` of
+`.venv/pyvenv.cfg`. Recreation allocates a new inode; in-place edits change
+mtime/size.
+
+### Check Triggers and Outcomes
+
+Checks are debounced to once per `TYPEMUX_CC_VENV_CHECK_INTERVAL` seconds
+(default 5; `0` disables tracking). Triggers: `ensure_backend_in_pool`
+(all venv-checked request methods), `didOpen`/`didChange` forwarding, and a
+60s background sweep (shared with the TTL timer, armed even when TTL is
+disabled).
+
+| Observation | Behavior |
+|-------------|----------|
+| Token unchanged | Serve as usual |
+| Token mismatch (venv replaced) | Evict old backend (cancel pending, clear diagnostics, shutdown), notify client via `window/showMessage`, respawn with the new environment — exactly once per change |
+| `pyvenv.cfg` missing < grace (2 × interval) | Keep serving the old backend (transient `uv sync` window) |
+| `pyvenv.cfg` missing ≥ grace | Evict without respawn; reset affected documents' cached venv so the next request re-resolves it — usually the strict-mode ".venv not found" error |
+
+The background sweep evicts without respawning (the next request lazily
+respawns), so an idle stale backend is corrected within ~60s even if no
+request ever targets it again.
+
+Staleness eviction reuses the standard eviction path, so the session-id
+mechanism guarantees late messages from the evicted process are discarded.
 
 ## Fan-Out for URI-less Requests
 
@@ -431,6 +475,7 @@ Documents under project-a/ are skipped. Skipped documents get empty diagnostics 
 | `$/cancelRequest` handling | Cancel warmup-queued requests without forwarding |
 | Fan-out requests | `workspace/symbol` dispatched to all backends with merged, deduplicated results |
 | Strict venv mode | Return errors when no venv found |
+| Venv identity tracking | Detect replaced/removed `.venv` (pyvenv.cfg identity token) and restart/evict the backend |
 | Diagnostics cleanup | Clear stale diagnostics on backend eviction |
 
 ## Logging Configuration

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Settings priority: **CLI flag > environment variable > config file > default**
 | `TYPEMUX_CC_MAX_BACKENDS` | Max concurrent backend processes | `8` |
 | `TYPEMUX_CC_BACKEND_TTL` | Backend TTL in seconds (0 = disabled) | `1800` |
 | `TYPEMUX_CC_FANOUT_TIMEOUT` | Fan-out timeout in seconds for `workspace/symbol` (0 = no timeout) | `5` |
+| `TYPEMUX_CC_VENV_CHECK_INTERVAL` | Interval in seconds between venv identity checks (0 = disable venv identity tracking) | `5` |
 | `RUST_LOG` | Log level | `typemux_cc=debug` |
 
 ## Typical Use Case
@@ -349,6 +350,9 @@ rm -rf ~/.claude/plugins/cache/typemux-cc-marketplace/
 
 > [!Note]
 > If `.venv` didn't exist when a file was first opened, typemux-cc automatically re-searches for it on the next LSP request. No need to reopen the file.
+
+> [!Note]
+> If `.venv` is **replaced** (e.g. `uv sync` recreating it), typemux-cc detects the change on the next LSP request and restarts the backend with the new environment automatically. If `.venv` is removed and not recreated, the backend is evicted after a short grace period and requests return an explicit error instead of stale results.
 
 ### "Project root is gitignored" Warning
 

--- a/src/backend_pool.rs
+++ b/src/backend_pool.rs
@@ -2,6 +2,7 @@ use crate::backend::{shutdown_fire_and_forget, BackendParts};
 use crate::error::BackendError;
 use crate::framing::{LspFrameReader, LspFrameWriter};
 use crate::message::{RpcId, RpcMessage};
+use crate::venv::VenvToken;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -44,6 +45,19 @@ pub fn fanout_timeout() -> Duration {
         .map_or(DEFAULT_FANOUT_TIMEOUT, Duration::from_secs)
 }
 
+/// Default venv staleness check interval (debounce); overridable via
+/// `TYPEMUX_CC_VENV_CHECK_INTERVAL` env var.
+const DEFAULT_VENV_CHECK_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Returns the debounce interval for pooled-backend venv identity checks.
+/// `TYPEMUX_CC_VENV_CHECK_INTERVAL=0` disables venv identity tracking entirely.
+pub fn venv_check_interval() -> Duration {
+    std::env::var("TYPEMUX_CC_VENV_CHECK_INTERVAL")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map_or(DEFAULT_VENV_CHECK_INTERVAL, Duration::from_secs)
+}
+
 /// Message from a backend reader task
 pub struct BackendMessage {
     pub venv_path: PathBuf,
@@ -63,6 +77,15 @@ pub struct BackendInstance {
     pub warmup_state: WarmupState,
     pub warmup_deadline: Instant,
     pub warmup_queue: Vec<RpcMessage>,
+    /// Identity token captured at spawn (`None` if capture raced a `.venv`
+    /// rebuild; adopted lazily on the first successful staleness check).
+    pub venv_token: Option<VenvToken>,
+    /// Debounce marker for `check_pooled_venv_staleness`.
+    pub last_venv_check: Instant,
+    /// Set when `pyvenv.cfg` was first observed missing; cleared once it
+    /// reappears. Used to bound how long a backend serves without a venv
+    /// before being treated as removed.
+    pub venv_missing_since: Option<Instant>,
 }
 
 impl BackendInstance {
@@ -73,6 +96,7 @@ impl BackendInstance {
         venv_path: PathBuf,
         session: u64,
         msg_sender: mpsc::Sender<BackendMessage>,
+        venv_token: Option<VenvToken>,
     ) -> Self {
         let reader_task = spawn_reader_task(parts.reader, msg_sender, venv_path.clone(), session);
         let timeout = warmup_timeout();
@@ -91,6 +115,9 @@ impl BackendInstance {
             },
             warmup_deadline: Instant::now() + timeout,
             warmup_queue: Vec::new(),
+            venv_token,
+            last_venv_check: Instant::now(),
+            venv_missing_since: None,
         }
     }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -223,6 +223,13 @@ pub async fn collect_doctor_report(
         source: env_only_source("TYPEMUX_CC_FANOUT_TIMEOUT", config_report),
     };
 
+    let venv_check_interval = backend_pool::venv_check_interval();
+    let venv_check_interval_item = ConfigItem {
+        name: "venv_check_interval".to_string(),
+        value: venv_check_interval.as_secs().to_string(),
+        source: env_only_source("TYPEMUX_CC_VENV_CHECK_INTERVAL", config_report),
+    };
+
     let log_file_value: String = matches
         .get_one::<PathBuf>("log_file")
         .map_or_else(|| "<not set>".to_string(), |p| p.display().to_string());
@@ -246,6 +253,7 @@ pub async fn collect_doctor_report(
             backend_ttl_item,
             warmup_timeout_item,
             fanout_timeout_item,
+            venv_check_interval_item,
             log_file_item,
         ],
     };

--- a/src/proxy/client_dispatch.rs
+++ b/src/proxy/client_dispatch.rs
@@ -45,9 +45,11 @@ impl super::LspProxy {
                 Ok(init_response) => {
                     // Split and insert into pool
                     let session = self.state.pool.next_session_id();
+                    let venv_token = crate::venv::venv_token(&venv).await;
                     let parts = backend.into_split();
                     let tx = self.state.pool.msg_sender();
-                    let instance = BackendInstance::from_parts(parts, venv.clone(), session, tx);
+                    let instance =
+                        BackendInstance::from_parts(parts, venv.clone(), session, tx, venv_token);
                     self.state.pool.insert(venv.clone(), instance);
 
                     // Send initialize response to client

--- a/src/proxy/diagnostics.rs
+++ b/src/proxy/diagnostics.rs
@@ -91,6 +91,32 @@ impl super::LspProxy {
         }
     }
 
+    /// Notify the client that a pooled backend's venv was replaced (e.g. by
+    /// `uv sync` recreating `.venv`) and the backend is being restarted.
+    pub(crate) async fn notify_venv_replaced(
+        &self,
+        venv_path: &Path,
+        client_writer: &mut LspFrameWriter<tokio::io::Stdout>,
+    ) {
+        let msg = RpcMessage::notification(
+            "window/showMessage",
+            Some(serde_json::json!({
+                "type": 3,
+                "message": format!(
+                    "typemux-cc: {} was replaced with a new environment; restarting the LSP backend.",
+                    venv_path.display()
+                )
+            })),
+        );
+
+        if let Err(e) = client_writer.write_message(&msg).await {
+            tracing::warn!(
+                error = ?e,
+                "Failed to send venv-replaced notification to client"
+            );
+        }
+    }
+
     /// Clear diagnostics for all documents belonging to a venv
     pub(crate) async fn clear_diagnostics_for_venv(
         &self,

--- a/src/proxy/document.rs
+++ b/src/proxy/document.rs
@@ -1,3 +1,4 @@
+use super::pool_management::StaleOutcome;
 use crate::error::ProxyError;
 use crate::framing::LspFrameWriter;
 use crate::message::RpcMessage;
@@ -109,8 +110,19 @@ impl super::LspProxy {
             }
         }
 
-        // Backend exists in pool — forward didOpen
-        self.forward_to_backend(venv_path, msg).await?;
+        // Backend exists in pool — verify its venv identity before forwarding.
+        match self
+            .check_pooled_venv_staleness(venv_path, client_writer)
+            .await?
+        {
+            StaleOutcome::Fresh => {
+                self.forward_to_backend(venv_path, msg).await?;
+            }
+            // Respawned: document restoration already replayed this didOpen
+            // to the new backend. Removed: cache-only revival mode, nothing
+            // to forward to.
+            StaleOutcome::Respawned | StaleOutcome::Removed => {}
+        }
 
         Ok(())
     }

--- a/src/proxy/initialization.rs
+++ b/src/proxy/initialization.rs
@@ -184,7 +184,10 @@ impl super::LspProxy {
         self.restore_documents_to_backend(&mut backend, venv, session, client_writer)
             .await?;
 
-        // 4. Split and create instance
+        // 4. Capture venv identity token (None if capture raced a rebuild)
+        let venv_token = crate::venv::venv_token(venv).await;
+
+        // 5. Split and create instance
         let parts = backend.into_split();
         let tx = self.state.pool.msg_sender();
         Ok(BackendInstance::from_parts(
@@ -192,6 +195,7 @@ impl super::LspProxy {
             venv.to_path_buf(),
             session,
             tx,
+            venv_token,
         ))
     }
 

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -11,6 +11,7 @@ use crate::error::ProxyError;
 use crate::framing::{LspFrameReader, LspFrameWriter};
 use crate::state::ProxyState;
 use crate::venv;
+use pool_management::StaleOutcome;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::io::{stdin, stdout};
@@ -115,10 +116,23 @@ impl LspProxy {
                         }
                         Some("textDocument/didChange") => {
                             self.handle_did_change(&msg)?;
-                            // Forward to appropriate backend
+                            // Forward to appropriate backend, after verifying
+                            // its venv identity hasn't gone stale.
                             if let Some(url) = Self::extract_text_document_uri(&msg) {
                                 if let Some(venv_path) = self.venv_for_uri(&url) {
-                                    self.forward_to_backend(&venv_path, &msg).await?;
+                                    match self
+                                        .check_pooled_venv_staleness(&venv_path, &mut client_writer)
+                                        .await?
+                                    {
+                                        StaleOutcome::Fresh => {
+                                            self.forward_to_backend(&venv_path, &msg).await?;
+                                        }
+                                        // Respawned: restoration already replayed the
+                                        // post-change cached text (handle_did_change
+                                        // updated the cache above). Removed:
+                                        // revival-preparation mode, nothing to forward to.
+                                        StaleOutcome::Respawned | StaleOutcome::Removed => {}
+                                    }
                                 }
                             }
                         }
@@ -152,9 +166,16 @@ impl LspProxy {
                     self.dispatch_backend_message(backend_msg, &mut client_writer).await?;
                 }
 
-                // TTL-based auto-eviction sweep
-                _ = ttl_interval.tick(), if self.backend_ttl.is_some() => {
-                    self.evict_expired_backends(&mut client_writer).await?;
+                // TTL-based auto-eviction and venv-identity staleness sweep.
+                // Always armed (not gated on backend_ttl) so the staleness
+                // sweep runs even when TTL eviction is disabled.
+                _ = ttl_interval.tick() => {
+                    if self.backend_ttl.is_some() {
+                        self.evict_expired_backends(&mut client_writer).await?;
+                    }
+                    if !crate::backend_pool::venv_check_interval().is_zero() {
+                        self.sweep_stale_venvs(&mut client_writer).await?;
+                    }
                 }
 
                 // Warmup timeout: fail-open transition for warming backends

--- a/src/proxy/pool_management.rs
+++ b/src/proxy/pool_management.rs
@@ -4,6 +4,30 @@ use crate::framing::LspFrameWriter;
 use crate::message::{RpcId, RpcMessage};
 use crate::venv;
 use std::path::{Path, PathBuf};
+use tokio::time::Instant;
+
+/// Outcome of a pooled-backend venv identity check
+/// (`check_pooled_venv_staleness`). See ARCHITECTURE.md's
+/// "Venv Identity Tracking" section for the full design.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StaleOutcome {
+    /// Venv identity unchanged (or the check was skipped/debounced).
+    Fresh,
+    /// The venv was replaced; the old backend was evicted and a new one spawned.
+    Respawned,
+    /// The venv was removed (missing beyond grace); the old backend was
+    /// evicted with no respawn.
+    Removed,
+}
+
+/// Result of inspecting a pooled backend's current venv identity, computed
+/// with the pool borrow released so eviction/respawn can follow.
+enum StaleDecision {
+    Fresh,
+    StillMissing,
+    Mismatch,
+    Removed,
+}
 
 impl super::LspProxy {
     /// Ensure a backend for the given URI's venv is in the pool.
@@ -46,25 +70,205 @@ impl super::LspProxy {
             None => return Ok(None),
         };
 
-        // Already in pool?
+        // Already in pool? Verify its venv identity hasn't gone stale before reusing it.
         if self.state.pool.contains(&target_venv) {
-            return Ok(Some(target_venv));
+            return match self
+                .check_pooled_venv_staleness(&target_venv, client_writer)
+                .await?
+            {
+                // Respawned: the new backend is in the pool under the same
+                // key; the caller still forwards its request to it. Restoration
+                // did not replay this specific request.
+                StaleOutcome::Fresh | StaleOutcome::Respawned => Ok(Some(target_venv)),
+                // Removed: no backend left for this venv; caller falls back
+                // to strict-mode ".venv not found" handling.
+                StaleOutcome::Removed => Ok(None),
+            };
         }
 
-        // Need to create a new backend. Evict if full.
+        // Need to create a new backend.
+        self.spawn_and_insert_backend(&target_venv, client_writer)
+            .await?;
+
+        Ok(Some(target_venv))
+    }
+
+    /// Evict-if-full, spawn a new backend for `venv`, insert it into the pool,
+    /// and warn if its project root is gitignored. Shared by pool-miss
+    /// resolution and venv-replacement respawn.
+    async fn spawn_and_insert_backend(
+        &mut self,
+        venv: &Path,
+        client_writer: &mut LspFrameWriter<tokio::io::Stdout>,
+    ) -> Result<(), ProxyError> {
         if self.state.pool.is_full() {
             self.evict_lru_backend(client_writer).await?;
         }
 
-        // Create backend instance
-        let instance = self
-            .create_backend_instance(&target_venv, client_writer)
-            .await?;
-        self.state.pool.insert(target_venv.clone(), instance);
-        self.warn_if_project_root_ignored(&target_venv, client_writer)
-            .await;
+        let instance = self.create_backend_instance(venv, client_writer).await?;
+        self.state.pool.insert(venv.to_path_buf(), instance);
+        self.warn_if_project_root_ignored(venv, client_writer).await;
 
-        Ok(Some(target_venv))
+        Ok(())
+    }
+
+    /// Debounced check for whether a pooled backend's venv identity (derived
+    /// from `.venv/pyvenv.cfg` metadata) has changed since it was last
+    /// observed. Debounced to once per `venv_check_interval()`; disabled
+    /// entirely when the interval is `0`.
+    ///
+    /// - Token mismatch: the venv was replaced. Evicts the old backend
+    ///   (cancelling pending requests, clearing diagnostics, shutting down)
+    ///   and respawns a new one via the same path pool-miss resolution uses.
+    /// - `pyvenv.cfg` missing: served as-is until `2 * venv_check_interval()`
+    ///   (grace) elapses, then evicted with no respawn; affected open
+    ///   documents' cached venv is reset so the next request re-resolves it.
+    pub(crate) async fn check_pooled_venv_staleness(
+        &mut self,
+        venv: &Path,
+        client_writer: &mut LspFrameWriter<tokio::io::Stdout>,
+    ) -> Result<StaleOutcome, ProxyError> {
+        let interval = crate::backend_pool::venv_check_interval();
+        if interval.is_zero() {
+            return Ok(StaleOutcome::Fresh);
+        }
+
+        let venv_path = venv.to_path_buf();
+        let now = Instant::now();
+        let due = self
+            .state
+            .pool
+            .get(&venv_path)
+            .is_some_and(|inst| now.duration_since(inst.last_venv_check) >= interval);
+        if !due {
+            return Ok(StaleOutcome::Fresh);
+        }
+
+        // Stat before taking the pool borrow: `venv_token` is async and the
+        // borrow must not be held across an `.await`.
+        let current_token = venv::venv_token(venv).await;
+        let grace = interval * 2;
+
+        let decision = {
+            let Some(inst) = self.state.pool.get_mut(&venv_path) else {
+                // Backend disappeared mid-check (race with another eviction path).
+                return Ok(StaleOutcome::Fresh);
+            };
+            inst.last_venv_check = Instant::now();
+
+            if let Some(token) = current_token {
+                inst.venv_missing_since = None;
+                if inst.venv_token.is_some_and(|old| old != token) {
+                    StaleDecision::Mismatch
+                } else {
+                    // Either it matches, or this is the first successful
+                    // stat after a spawn-time capture race — adopt it.
+                    inst.venv_token = Some(token);
+                    StaleDecision::Fresh
+                }
+            } else {
+                let missing_since = *inst.venv_missing_since.get_or_insert(now);
+                if now.duration_since(missing_since) >= grace {
+                    StaleDecision::Removed
+                } else {
+                    StaleDecision::StillMissing
+                }
+            }
+        };
+
+        match decision {
+            StaleDecision::Fresh | StaleDecision::StillMissing => Ok(StaleOutcome::Fresh),
+            StaleDecision::Mismatch => {
+                self.evict_pooled_backend(&venv_path, client_writer).await?;
+                self.notify_venv_replaced(&venv_path, client_writer).await;
+                self.spawn_and_insert_backend(&venv_path, client_writer)
+                    .await?;
+                Ok(StaleOutcome::Respawned)
+            }
+            StaleDecision::Removed => {
+                // Clear diagnostics (filtered by `doc.venv == venv_path`)
+                // BEFORE resetting `doc.venv` below — ordering is load-bearing.
+                self.evict_pooled_backend(&venv_path, client_writer).await?;
+                self.reset_doc_venv_for(&venv_path);
+                Ok(StaleOutcome::Removed)
+            }
+        }
+    }
+
+    /// Remove and clean up the pooled backend for `venv_path`, if present.
+    async fn evict_pooled_backend(
+        &mut self,
+        venv_path: &PathBuf,
+        client_writer: &mut LspFrameWriter<tokio::io::Stdout>,
+    ) -> Result<(), ProxyError> {
+        if let Some(instance) = self.state.pool.remove(venv_path) {
+            let session = instance.session;
+            self.cleanup_evicted_backend(instance, venv_path, session, client_writer, true)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Reset the cached venv of all open documents pointing at `venv_path`
+    /// to `None`, so the next request re-resolves it via `find_venv`.
+    fn reset_doc_venv_for(&mut self, venv_path: &Path) {
+        for doc in self.state.open_documents.values_mut() {
+            if doc.venv.as_deref() == Some(venv_path) {
+                doc.venv = None;
+            }
+        }
+    }
+
+    /// TTL-sweep-adjacent staleness pass: evict (without respawning) any
+    /// pooled backend whose venv was replaced or has been missing beyond
+    /// grace. Log-only — no `window/showMessage`, no restoration. The next
+    /// request lazily respawns via `ensure_backend_in_pool`. Skipped when
+    /// venv identity tracking is disabled (`venv_check_interval() == 0`).
+    pub(crate) async fn sweep_stale_venvs(
+        &mut self,
+        client_writer: &mut LspFrameWriter<tokio::io::Stdout>,
+    ) -> Result<(), ProxyError> {
+        let interval = crate::backend_pool::venv_check_interval();
+        if interval.is_zero() {
+            return Ok(());
+        }
+        let grace = interval * 2;
+        let now = Instant::now();
+
+        for venv_path in self.state.pool.backends_keys() {
+            let current_token = venv::venv_token(&venv_path).await;
+
+            let should_evict = {
+                let Some(inst) = self.state.pool.get_mut(&venv_path) else {
+                    continue;
+                };
+                if let Some(token) = current_token {
+                    let mismatch = inst.venv_token.is_some_and(|old| old != token);
+                    inst.venv_missing_since = None;
+                    mismatch
+                } else {
+                    let missing_since = *inst.venv_missing_since.get_or_insert(now);
+                    now.duration_since(missing_since) >= grace
+                }
+            };
+
+            if !should_evict {
+                continue;
+            }
+
+            tracing::info!(
+                venv = %venv_path.display(),
+                reason = if current_token.is_some() { "replaced" } else { "removed" },
+                "Sweep: evicting stale pooled backend"
+            );
+
+            self.evict_pooled_backend(&venv_path, client_writer).await?;
+            if current_token.is_none() {
+                self.reset_doc_venv_for(&venv_path);
+            }
+        }
+
+        Ok(())
     }
 
     /// Evict the LRU backend from the pool

--- a/src/venv.rs
+++ b/src/venv.rs
@@ -1,9 +1,37 @@
 use crate::error::VenvError;
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 use tokio::process::Command;
 
 const VENV_DIR: &str = ".venv";
 const PYVENV_CFG: &str = "pyvenv.cfg";
+
+/// Identity token for a `.venv`, derived from `.venv/pyvenv.cfg` metadata.
+///
+/// `uv sync` recreating `.venv` allocates a new inode (`dev`/`ino` change);
+/// in-place edits change `mtime`/`size`. `size` hardens against the rare case
+/// of inode reuse combined with a coarse mtime collision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VenvToken {
+    dev: u64,
+    ino: u64,
+    mtime: SystemTime,
+    size: u64,
+}
+
+/// Stat `.venv/pyvenv.cfg` and capture its identity token.
+/// Returns `None` if the file cannot be stat'd (missing, permission error, etc.).
+pub async fn venv_token(venv: &Path) -> Option<VenvToken> {
+    let meta = tokio::fs::metadata(venv.join(PYVENV_CFG)).await.ok()?;
+    let mtime = meta.modified().ok()?;
+    Some(VenvToken {
+        dev: meta.dev(),
+        ino: meta.ino(),
+        mtime,
+        size: meta.len(),
+    })
+}
 
 /// Execute git rev-parse --show-toplevel and get result
 pub async fn get_git_toplevel(working_dir: &Path) -> Result<Option<PathBuf>, VenvError> {
@@ -264,5 +292,50 @@ mod tests {
         fs::create_dir(&some_dir).await.unwrap();
 
         assert!(!is_path_git_ignored(&some_dir, &root).await);
+    }
+
+    #[tokio::test]
+    async fn test_venv_token_stable_across_restat() {
+        let temp = tempdir().unwrap();
+        let venv = temp.path().join(".venv");
+        fs::create_dir(&venv).await.unwrap();
+        fs::write(venv.join("pyvenv.cfg"), "home = /usr/bin")
+            .await
+            .unwrap();
+
+        let token1 = venv_token(&venv).await;
+        let token2 = venv_token(&venv).await;
+        assert!(token1.is_some());
+        assert_eq!(token1, token2);
+    }
+
+    #[tokio::test]
+    async fn test_venv_token_changes_on_recreate() {
+        let temp = tempdir().unwrap();
+        let venv = temp.path().join(".venv");
+        fs::create_dir(&venv).await.unwrap();
+        fs::write(venv.join("pyvenv.cfg"), "home = /usr/bin")
+            .await
+            .unwrap();
+        let token1 = venv_token(&venv).await;
+
+        // Recreate with different content (different size and inode).
+        fs::remove_file(venv.join("pyvenv.cfg")).await.unwrap();
+        fs::write(venv.join("pyvenv.cfg"), "home = /usr/bin\nversion = 2")
+            .await
+            .unwrap();
+        let token2 = venv_token(&venv).await;
+
+        assert!(token1.is_some());
+        assert!(token2.is_some());
+        assert_ne!(token1, token2);
+    }
+
+    #[tokio::test]
+    async fn test_venv_token_missing_is_none() {
+        let temp = tempdir().unwrap();
+        let venv = temp.path().join(".venv");
+
+        assert!(venv_token(&venv).await.is_none());
     }
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -50,39 +50,48 @@ pub fn setup_test_workspace(config: &WorkspaceConfig) -> (TempDir, PathBuf) {
     std::fs::create_dir_all(root.join(".git/refs/heads")).unwrap();
     std::fs::create_dir_all(root.join(".git/objects")).unwrap();
 
-    let mock_backend_bin = env!("CARGO_BIN_EXE_mock-lsp-backend");
-
     for pkg in &config.packages {
         let pkg_dir = root.join(&pkg.name);
         std::fs::create_dir_all(&pkg_dir).unwrap();
 
         if pkg.has_venv {
-            let venv_dir = pkg_dir.join(".venv");
-            std::fs::create_dir_all(venv_dir.join("bin")).unwrap();
-            std::fs::write(venv_dir.join("pyvenv.cfg"), "home = /usr/bin\n").unwrap();
-
-            // Write scenario file into the venv.
-            let scenario_json = serde_json::to_string_pretty(&pkg.scenario).unwrap();
-            std::fs::write(venv_dir.join("scenario.json"), &scenario_json).unwrap();
-
-            // Fake pyright-langserver that bridges to mock-lsp-backend.
-            let script = format!(
-                "#!/bin/sh\nexport MOCK_LSP_SCENARIO_FILE=\"$VIRTUAL_ENV/scenario.json\"\nexec \"{}\" \"$@\"\n",
-                mock_backend_bin
-            );
-            let script_path = venv_dir.join("bin/pyright-langserver");
-            std::fs::write(&script_path, &script).unwrap();
-
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
-                    .unwrap();
-            }
+            write_venv_fixture(&pkg_dir, &pkg.scenario);
         }
     }
 
     (temp, root)
+}
+
+/// Create (or recreate) `<pkg_dir>/.venv` with a `pyvenv.cfg`, a
+/// `scenario.json` for the mock backend, and a fake `pyright-langserver`
+/// shim that bridges to `mock-lsp-backend`.
+///
+/// Used both by `setup_test_workspace` (initial fixture) and by tests that
+/// simulate `uv sync` recreating `.venv` mid-run (venv identity tracking).
+pub fn write_venv_fixture(pkg_dir: &Path, scenario: &Value) {
+    let mock_backend_bin = env!("CARGO_BIN_EXE_mock-lsp-backend");
+
+    let venv_dir = pkg_dir.join(".venv");
+    std::fs::create_dir_all(venv_dir.join("bin")).unwrap();
+    std::fs::write(venv_dir.join("pyvenv.cfg"), "home = /usr/bin\n").unwrap();
+
+    // Write scenario file into the venv.
+    let scenario_json = serde_json::to_string_pretty(scenario).unwrap();
+    std::fs::write(venv_dir.join("scenario.json"), &scenario_json).unwrap();
+
+    // Fake pyright-langserver that bridges to mock-lsp-backend.
+    let script = format!(
+        "#!/bin/sh\nexport MOCK_LSP_SCENARIO_FILE=\"$VIRTUAL_ENV/scenario.json\"\nexec \"{}\" \"$@\"\n",
+        mock_backend_bin
+    );
+    let script_path = venv_dir.join("bin/pyright-langserver");
+    std::fs::write(&script_path, &script).unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
 }
 
 // ── ProxyUnderTest ──────────────────────────────────────────────────
@@ -101,7 +110,19 @@ pub struct ProxyUnderTest {
 
 impl ProxyUnderTest {
     /// Spawn the proxy binary with the given workspace as cwd.
+    #[allow(dead_code)] // Used by some but not all integration test binaries.
     pub fn spawn(temp_dir: TempDir, root: PathBuf, cwd: &Path) -> Self {
+        Self::spawn_with_env(temp_dir, root, cwd, &[])
+    }
+
+    /// Spawn the proxy binary with the given workspace as cwd and additional
+    /// environment variables (e.g. `TYPEMUX_CC_VENV_CHECK_INTERVAL`).
+    pub fn spawn_with_env(
+        temp_dir: TempDir,
+        root: PathBuf,
+        cwd: &Path,
+        envs: &[(&str, &str)],
+    ) -> Self {
         let proxy_bin = env!("CARGO_BIN_EXE_typemux-cc");
         let mut child = Command::new(proxy_bin)
             .current_dir(cwd)
@@ -111,6 +132,7 @@ impl ProxyUnderTest {
             .env_remove("GIT_DIR")
             .env_remove("GIT_WORK_TREE")
             .env_remove("GIT_INDEX_FILE")
+            .envs(envs.iter().copied())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/tests/venv_staleness_test.rs
+++ b/tests/venv_staleness_test.rs
@@ -1,0 +1,259 @@
+mod support;
+
+use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
+
+/// E2E: venv identity tracking — a replaced `.venv` (e.g. `uv sync`) is
+/// detected on the next debounced check and the backend is respawned with
+/// the new environment, exactly once.
+///
+/// These are the suite's first timing-based tests. `TYPEMUX_CC_VENV_CHECK_INTERVAL=1`
+/// keeps them short; sleeps carry generous margins over the 1s debounce and
+/// the 2s (= 2 × interval) missing-file grace to absorb CI jitter.
+#[tokio::test]
+async fn replaced_venv_triggers_single_backend_respawn() {
+    // First lifetime: hover works against the original venv.
+    let scenario_life1 = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            // dispatch_initialized forwards a 2nd "initialized" to fallback backends
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover life1" } } }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![PackageConfig {
+            name: "pkg".to_string(),
+            scenario: scenario_life1,
+            has_venv: true,
+        }],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    let pkg_dir = root.join("pkg");
+    let mut proxy = ProxyUnderTest::spawn_with_env(
+        temp_dir,
+        root.clone(),
+        &pkg_dir,
+        &[("TYPEMUX_CC_VENV_CHECK_INTERVAL", "1")],
+    );
+
+    let root_uri = support::path_to_uri(&pkg_dir);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file_a = pkg_dir.join("a.py");
+    std::fs::write(&file_a, "a = 1\n").unwrap();
+    let file_a_uri = support::path_to_uri(&file_a);
+    proxy.did_open(&file_a_uri, "a = 1\n").await;
+
+    let hover_params = serde_json::json!({
+        "textDocument": { "uri": &file_a_uri },
+        "position": { "line": 0, "character": 0 }
+    });
+
+    // First hover lands within the debounce window: no staleness check yet.
+    let hover1 = proxy
+        .request("textDocument/hover", hover_params.clone())
+        .await;
+    assert!(
+        hover1.error.is_none(),
+        "hover against original venv should succeed, got error: {:?}",
+        hover1.error
+    );
+    assert_eq!(
+        hover1.result.as_ref().unwrap()["contents"]["value"],
+        "hover life1"
+    );
+
+    // Simulate `uv sync`: delete and recreate `.venv`. The sleep separates
+    // the two pyvenv.cfg files in mtime and defeats inode-reuse collisions,
+    // and also pushes past the 1s debounce so the next hover checks.
+    std::fs::remove_dir_all(pkg_dir.join(".venv")).unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+
+    // Second lifetime: the respawned backend restores a.py and serves hover.
+    let scenario_life2 = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover life2" } } }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+    support::write_venv_fixture(&pkg_dir, &scenario_life2);
+    // Different-length pyvenv.cfg content: belt-and-braces against the
+    // identity token missing an inode/mtime collision.
+    std::fs::write(
+        pkg_dir.join(".venv/pyvenv.cfg"),
+        "home = /usr/bin\nversion = 3.12\n",
+    )
+    .unwrap();
+
+    // A spurious extra respawn would double-consume life2's scenario steps
+    // and fail this hover, so the assertion below also proves "exactly once".
+    let (hover2, notifications) = proxy
+        .request_collecting("textDocument/hover", hover_params)
+        .await;
+    assert!(
+        hover2.error.is_none(),
+        "hover after venv replacement should succeed, got error: {:?}",
+        hover2.error
+    );
+    assert_eq!(
+        hover2.result.as_ref().unwrap()["contents"]["value"],
+        "hover life2"
+    );
+
+    // The replacement must be announced to the client.
+    let replaced_notice = notifications.iter().any(|n| {
+        n.method.as_deref() == Some("window/showMessage")
+            && n.params
+                .as_ref()
+                .and_then(|p| p["message"].as_str())
+                .is_some_and(|m| m.contains("replaced"))
+    });
+    assert!(
+        replaced_notice,
+        "expected a window/showMessage about the replaced venv, got: {notifications:?}"
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}
+
+/// E2E: a `.venv` whose `pyvenv.cfg` disappears is served during the grace
+/// window (transient `uv sync` gap), then evicted without respawn — strict
+/// mode returns an explicit error instead of silently serving stale results.
+#[tokio::test]
+async fn removed_venv_evicts_after_grace_and_errors() {
+    let scenario = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover before removal" } } }]
+            },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover during grace" } } }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![PackageConfig {
+            name: "pkg".to_string(),
+            scenario,
+            has_venv: true,
+        }],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    let pkg_dir = root.join("pkg");
+    let mut proxy = ProxyUnderTest::spawn_with_env(
+        temp_dir,
+        root.clone(),
+        &pkg_dir,
+        &[("TYPEMUX_CC_VENV_CHECK_INTERVAL", "1")],
+    );
+
+    let root_uri = support::path_to_uri(&pkg_dir);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file_a = pkg_dir.join("a.py");
+    std::fs::write(&file_a, "a = 1\n").unwrap();
+    let file_a_uri = support::path_to_uri(&file_a);
+    proxy.did_open(&file_a_uri, "a = 1\n").await;
+
+    let hover_params = serde_json::json!({
+        "textDocument": { "uri": &file_a_uri },
+        "position": { "line": 0, "character": 0 }
+    });
+
+    let hover1 = proxy
+        .request("textDocument/hover", hover_params.clone())
+        .await;
+    assert!(hover1.error.is_none());
+    assert_eq!(
+        hover1.result.as_ref().unwrap()["contents"]["value"],
+        "hover before removal"
+    );
+
+    // Remove pyvenv.cfg only (mid-`uv sync` state). Past the 1s debounce
+    // but well inside the 2s grace: the old backend still serves.
+    std::fs::remove_file(pkg_dir.join(".venv/pyvenv.cfg")).unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+
+    let hover2 = proxy
+        .request("textDocument/hover", hover_params.clone())
+        .await;
+    assert!(
+        hover2.error.is_none(),
+        "hover within grace should still be served by the old backend, got error: {:?}",
+        hover2.error
+    );
+    assert_eq!(
+        hover2.result.as_ref().unwrap()["contents"]["value"],
+        "hover during grace"
+    );
+
+    // Push past grace (2s since the missing mark) with margin: the backend
+    // is evicted without respawn and strict mode reports the missing venv.
+    tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
+
+    let hover3 = proxy.request("textDocument/hover", hover_params).await;
+    let error = hover3
+        .error
+        .expect("hover after grace must fail: venv is gone (strict mode)");
+    assert!(
+        error.message.contains(".venv not found"),
+        "expected strict-mode '.venv not found' error, got: {}",
+        error.message
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}


### PR DESCRIPTION
## Summary

The backend pool identified backends by **venv path only**, so a `.venv` deleted and recreated by `uv sync` kept the old backend serving results from the stale environment — violating the project's core design principle: *"A Silently Lying LSP Is the Worst"* (ARCHITECTURE.md).

This PR adds **venv identity tracking**: each backend captures an identity token (`dev`/`ino`/`mtime`/`size` of `.venv/pyvenv.cfg`) at spawn, and a debounced check detects when the venv is replaced or removed.

## Behavior

| Observation | Behavior |
|---|---|
| Token unchanged | Serve as usual |
| Token mismatch (venv replaced) | Evict old backend, notify the client via `window/showMessage`, respawn with the new environment — exactly once per change |
| `pyvenv.cfg` missing < grace (2 × interval) | Keep serving the old backend (transient `uv sync` window; no restart storm) |
| `pyvenv.cfg` missing ≥ grace | Evict without respawn; reset affected documents' cached venv → strict-mode `.venv not found` error instead of stale results |

**Check triggers**: `ensure_backend_in_pool` (all venv-checked request methods), `didOpen`/`didChange` forwarding, and a 60s background sweep sharing the TTL timer (now always armed) that evicts idle stale backends without respawn — the next request respawns lazily.

**Config**: `TYPEMUX_CC_VENV_CHECK_INTERVAL` (default 5s, `0` = disabled), surfaced in `--doctor`.

## Design notes

- Staleness eviction reuses the existing eviction path (`cleanup_evicted_backend`): pending-request cancellation, fan-out convergence, diagnostics cleanup, and the session-id stale-message discard all apply unchanged.
- Ordering is load-bearing in the removal path: diagnostics are cleared (filtered by `doc.venv`) **before** the cached venv is reset.
- The design was red-teamed before implementation; the didChange coverage, diagnostics-ordering, grace semantics, and the background sweep all came out of that review.

## Tests

- Unit: `VenvToken` capture/compare (stable re-stat, recreation changes token, missing → None)
- E2E `replaced_venv_triggers_single_backend_respawn`: hover served by the old env → `.venv` recreated → next hover served by the respawned backend; a duplicate respawn would double-consume the mock scenario and fail; asserts the client notification
- E2E `removed_venv_evicts_after_grace_and_errors`: within grace the old backend still serves; past grace the request returns the strict-mode error
- These are the suite's first timing-based E2E tests (`TYPEMUX_CC_VENV_CHECK_INTERVAL=1`, generous margins, ~4-5s each)
- `make all` (fmt + clippy -D warnings + full suite) passes

## Docs

- README: config table row + `.venv` Not Switching callout
- ARCHITECTURE.md: new "Venv Identity Tracking" section; "Cache Limitation" rewritten to distinguish document-venv-cache staleness from backend-pool-identity staleness