### PR TITLE
docs: reference upstream issues the project addresses in the intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This is especially painful with **git worktrees**, now common in AI-assisted dev
 
 typemux-cc is a Python LSP proxy that fixes this — `.venv` changes are reflected **within your running session**, no restarts required.
 
+This is a recurring, unresolved pain in the Claude Code ecosystem: worktree/venv breakage keeps being reported upstream — [anthropics/claude-code#31391](https://github.com/anthropics/claude-code/issues/31391) (closed as *not planned*), [astral-sh/claude-code-plugins#18](https://github.com/astral-sh/claude-code-plugins/issues/18) (open), [anthropics/claude-code#58365](https://github.com/anthropics/claude-code/issues/58365) — while the official pyright plugin remains a single `pyright-langserver` spawn with no environment handling. typemux-cc exists to solve the environment-lifecycle side of this problem for Python.
+
 ## Quickstart
 
 ```bash


### PR DESCRIPTION
## Summary

Adds one paragraph to the README intro grounding the problem statement in the ecosystem, per the maintainer's suggestion to link the official issues near the top.

## Fact-checked claims (verified against the trackers on 2026-07-11)

- [anthropics/claude-code#31391](https://github.com/anthropics/claude-code/issues/31391) — LSP not detected in a git worktree (VS Code + astral plugin). **Closed as not planned**, i.e. unresolved upstream.
- [astral-sh/claude-code-plugins#18](https://github.com/astral-sh/claude-code-plugins/issues/18) — same pain on the astral plugin tracker, **still open**.
- [anthropics/claude-code#58365](https://github.com/anthropics/claude-code/issues/58365) — pyright plugin ignoring `venvPath`/`venv` config, producing `reportMissingImports` false positives.
- The official pyright plugin is a bare `lspServers` entry spawning `pyright-langserver` once, with no environment handling (verified against the plugin source in claude-plugins-official).

## Wording notes

- Deliberately does **not** claim to fix #31391 itself (different mechanism: LSP *detection* in the VS Code extension vs environment lifecycle) — the paragraph frames these as evidence of the recurring pain class and scopes typemux-cc's claim to "the environment-lifecycle side".
- The gitignore-filter side of worktree breakage (anthropics/claude-code#76371, #72594) is intentionally not cited here; typemux-cc surfaces it with a warning but does not fix it (already covered in Known Limitations).