### PR TITLE
chore: add marketplace description for plugin validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "typemux-cc-marketplace",
+  "description": "Marketplace for typemux-cc, a Python type-checker LSP multiplexer for Claude Code: per-venv backend pooling, late .venv detection, and environment change tracking for pyright, ty, and pyrefly.",
   "owner": {
     "name": "K-dash"
   },


### PR DESCRIPTION
Fixes the single warning from `claude plugin validate` (missing marketplace description). Validation now passes clean. Prerequisite for submitting the plugin to the claude-community marketplace review, whose pipeline runs the same check.