### PR TITLE
feat: verify release binary checksums in installer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "typemux-cc-marketplace",
+  "description": "Marketplace for typemux-cc, a Python type-checker LSP multiplexer for Claude Code: per-venv backend pooling, late .venv detection, and environment change tracking for pyright, ty, and pyrefly.",
   "owner": {
     "name": "K-dash"
   },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,15 @@ jobs:
           cp target/${{ matrix.target }}/release/typemux-cc ${{ matrix.binary_name }}
           chmod +x ${{ matrix.binary_name }}
 
+      - name: Generate checksum
+        run: shasum -a 256 ${{ matrix.binary_name }} > ${{ matrix.binary_name }}.sha256
+
       - name: Upload to release
         uses: softprops/action-gh-release@v3
         with:
-          files: ${{ matrix.binary_name }}
+          files: |
+            ${{ matrix.binary_name }}
+            ${{ matrix.binary_name }}.sha256
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ After installation, verify in `~/.claude/settings.json`:
 /plugin marketplace remove typemux-cc-marketplace
 ```
 
+### How the Installer Verifies Binaries
+
+The plugin's SessionStart hook downloads the prebuilt binary for your platform from this repository's GitHub Releases over HTTPS, pinned to the plugin's own version tag (never "latest"). Before the downloaded binary is executed or activated, the installer:
+
+1. Verifies its SHA256 checksum against the `.sha256` asset published alongside it by the [release workflow](.github/workflows/release.yml)
+2. Confirms the binary reports the expected version
+
+On any failure it keeps the previously working binary and prints an explicit warning, or fails loudly if no binary exists yet. Binaries are built from the tagged commit by GitHub Actions — nothing is built or fetched from anywhere else.
+
 ### Method B: Local Build (For Developers)
 
 > Requires Rust 1.75 or later.

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,14 @@ binary_version() {
   "$1" --version 2>/dev/null | awk '{print $2}'
 }
 
+file_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
 # Skip only when the existing binary matches the plugin version. A bare
 # existence check is not enough: a gitignored binary left in the
 # marketplace clone gets copied into every new plugin version's cache
@@ -89,6 +97,20 @@ if ! curl -fsSL -o "${TMP_PATH}" "${DOWNLOAD_URL}"; then
   fi
   echo "[typemux-cc] ERROR: Failed to download binary from ${DOWNLOAD_URL}" >&2
   echo "[typemux-cc] Please check https://github.com/${REPO}/releases for available binaries" >&2
+  exit 1
+fi
+
+# Verify integrity against the release's checksum asset BEFORE executing
+# the downloaded binary. No checksum, no install.
+EXPECTED_SHA=$(curl -fsSL "${DOWNLOAD_URL}.sha256" 2>/dev/null | awk '{print $1}' || true)
+ACTUAL_SHA=$(file_sha256 "${TMP_PATH}")
+if [ -z "${EXPECTED_SHA}" ] || [ "${ACTUAL_SHA}" != "${EXPECTED_SHA}" ]; then
+  rm -f "${TMP_PATH}"
+  if [ -f "${BINARY_PATH}" ]; then
+    echo "[typemux-cc] WARNING: checksum verification failed (expected ${EXPECTED_SHA:-unavailable}, got ${ACTUAL_SHA}); keeping existing binary" >&2
+    exit 0
+  fi
+  echo "[typemux-cc] ERROR: checksum verification failed for ${DOWNLOAD_URL} (expected ${EXPECTED_SHA:-unavailable}, got ${ACTUAL_SHA})" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Supply-chain hardening ahead of the claude-community marketplace submission: the installer previously downloaded the release binary over HTTPS and checked its `--version`, but executed the unverified binary to do so and had no integrity check.

## Changes

- **release.yml**: each matrix job publishes `<binary>.sha256` (`shasum -a 256`) alongside its binary
- **install.sh**: downloads `<asset>.sha256`, verifies the SHA256 **before** the binary is ever executed (the version check now runs on a verified file). Missing checksum or mismatch → keep the previously working binary with an explicit WARNING, or hard-fail if none exists. Portable hashing (`sha256sum` → `shasum -a 256` fallback)
- **README**: new "How the Installer Verifies Binaries" section documenting the pinned-version HTTPS download + checksum + version verification chain

## Verification

- `bash -n` clean; `claude plugin validate` passes
- Live failure-path tests against the real v0.2.14 release (which has no `.sha256` asset): with an existing binary → WARNING + keep (verified the old binary survives); without → exit 1
- Happy path requires a release that carries checksums — will be verified live immediately after v0.2.15 is published (fresh fixture install + checksum match)

Note: releases ≤ v0.2.14 have no checksum assets, but each shipped install.sh only ever downloads its own plugin version, so old plugin versions keep using their own (old) installer — no compatibility path needed.