### PR TITLE
fix: generate release notes once instead of per matrix job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,24 @@ permissions:
   contents: write
 
 jobs:
+  # Create the release (with generated notes) exactly once, before any
+  # build job touches it. Running generate_release_notes from each matrix
+  # job appends another copy of the notes on every update, duplicating
+  # the "What's Changed" section.
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub release with generated notes
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     name: Build ${{ matrix.target }}
+    needs: create-release
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -59,6 +75,5 @@ jobs:
           files: |
             ${{ matrix.binary_name }}
             ${{ matrix.binary_name }}.sha256
-          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Every release's notes contained the **What's Changed** section two (or more) times — the maintainer has been deleting the duplicates by hand since at least 0.2.14.

## Root cause (verified on the v0.2.15 run)

All three matrix build jobs ran `softprops/action-gh-release@v3` with `generate_release_notes: true` against the same tag. Job finish times: x86_64 22:41:00 (created the release + notes), macos 22:41:03 (updated the existing release → **appended a second generated copy**), arm64 22:42:35. The duplicate count is a race artifact of job finish order, which matches the historically inconsistent duplication.

## Fix

- New `create-release` job creates the GitHub release with generated notes **exactly once**, before any build runs
- The matrix `build` jobs now `needs: create-release` and call the release action with `files:` only — no `generate_release_notes` — so updates attach assets without touching the body (the action leaves omitted fields intact)

## Verification

- v0.2.15's published body was already cleaned up manually via `gh release edit` (single What's Changed confirmed)
- The workflow change itself can only be end-to-end verified by the next tag push; will confirm on the next release. If earlier verification is wanted, a throwaway prerelease tag can exercise it — say the word.