### PR TITLE
chore: add CODEOWNERS with default repository owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repository
+* @K-dash


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning @K-dash as the default owner for all paths, so review requests are raised automatically on pull requests (e.g. Renovate updates and external contributions). Note: GitHub does not self-request review on the owner's own PRs.