### PR TITLE
fix: contain backend respawn failures in venv staleness check

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -244,6 +244,7 @@ disabled).
 |-------------|----------|
 | Token unchanged | Serve as usual |
 | Token mismatch (venv replaced) | Evict old backend (cancel pending, clear diagnostics, shutdown), notify client via `window/showMessage`, respawn with the new environment — exactly once per change |
+| Token mismatch, respawn fails (e.g. broken interpreter mid-`uv sync`) | Contained, never fatal: notify the client via `window/showMessage`, keep serving other venvs; the next request for this venv retries backend creation via the pool-miss path |
 | `pyvenv.cfg` missing < grace (2 × interval) | Keep serving the old backend (transient `uv sync` window) |
 | `pyvenv.cfg` missing ≥ grace | Evict without respawn; reset affected documents' cached venv so the next request re-resolves it — usually the strict-mode ".venv not found" error |
 

--- a/src/proxy/document.rs
+++ b/src/proxy/document.rs
@@ -122,6 +122,11 @@ impl super::LspProxy {
             // to the new backend. Removed: cache-only revival mode, nothing
             // to forward to.
             StaleOutcome::Respawned | StaleOutcome::Removed => {}
+            // Respawn failure is contained (mirrors the pool-miss arm above).
+            StaleOutcome::RespawnFailed(e) => {
+                self.notify_backend_error(venv_path, &e, client_writer)
+                    .await;
+            }
         }
 
         Ok(())

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -132,6 +132,11 @@ impl LspProxy {
                                         // updated the cache above). Removed:
                                         // revival-preparation mode, nothing to forward to.
                                         StaleOutcome::Respawned | StaleOutcome::Removed => {}
+                                        // Respawn failure is contained: notify the
+                                        // client; the next request retries lazily.
+                                        StaleOutcome::RespawnFailed(e) => {
+                                            self.notify_backend_error(&venv_path, &e, &mut client_writer).await;
+                                        }
                                     }
                                 }
                             }

--- a/src/proxy/pool_management.rs
+++ b/src/proxy/pool_management.rs
@@ -9,7 +9,7 @@ use tokio::time::Instant;
 /// Outcome of a pooled-backend venv identity check
 /// (`check_pooled_venv_staleness`). See ARCHITECTURE.md's
 /// "Venv Identity Tracking" section for the full design.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) enum StaleOutcome {
     /// Venv identity unchanged (or the check was skipped/debounced).
     Fresh,
@@ -18,6 +18,10 @@ pub(crate) enum StaleOutcome {
     /// The venv was removed (missing beyond grace); the old backend was
     /// evicted with no respawn.
     Removed,
+    /// The venv was replaced and the old backend evicted, but spawning the
+    /// replacement failed. The pool entry is gone, so the next request for
+    /// this venv retries via the pool-miss path.
+    RespawnFailed(ProxyError),
 }
 
 /// Result of inspecting a pooled backend's current venv identity, computed
@@ -83,6 +87,10 @@ impl super::LspProxy {
                 // Removed: no backend left for this venv; caller falls back
                 // to strict-mode ".venv not found" handling.
                 StaleOutcome::Removed => Ok(None),
+                // RespawnFailed: surface the creation error through the
+                // callers' existing containment (didOpen notifies, requests
+                // get a JSON-RPC error response).
+                StaleOutcome::RespawnFailed(e) => Err(e),
             };
         }
 
@@ -120,6 +128,8 @@ impl super::LspProxy {
     /// - Token mismatch: the venv was replaced. Evicts the old backend
     ///   (cancelling pending requests, clearing diagnostics, shutting down)
     ///   and respawns a new one via the same path pool-miss resolution uses.
+    ///   A failed respawn is contained as `StaleOutcome::RespawnFailed` —
+    ///   never propagated as a fatal error.
     /// - `pyvenv.cfg` missing: served as-is until `2 * venv_check_interval()`
     ///   (grace) elapses, then evicted with no respawn; affected open
     ///   documents' cached venv is reset so the next request re-resolves it.
@@ -181,9 +191,23 @@ impl super::LspProxy {
             StaleDecision::Mismatch => {
                 self.evict_pooled_backend(&venv_path, client_writer).await?;
                 self.notify_venv_replaced(&venv_path, client_writer).await;
-                self.spawn_and_insert_backend(&venv_path, client_writer)
-                    .await?;
-                Ok(StaleOutcome::Respawned)
+                // One venv's failed respawn must not take down the whole
+                // proxy: the old backend is already evicted, so return the
+                // error as an outcome and let the next request retry lazily.
+                match self
+                    .spawn_and_insert_backend(&venv_path, client_writer)
+                    .await
+                {
+                    Ok(()) => Ok(StaleOutcome::Respawned),
+                    Err(e) => {
+                        tracing::error!(
+                            venv = %venv_path.display(),
+                            error = ?e,
+                            "Respawn after venv replacement failed"
+                        );
+                        Ok(StaleOutcome::RespawnFailed(e))
+                    }
+                }
             }
             StaleDecision::Removed => {
                 // Clear diagnostics (filtered by `doc.venv == venv_path`)

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -94,6 +94,31 @@ pub fn write_venv_fixture(pkg_dir: &Path, scenario: &Value) {
     }
 }
 
+/// Create (or recreate) `<pkg_dir>/.venv` whose fake `pyright-langserver`
+/// exits immediately, so backend creation fails deterministically at the
+/// initialize handshake. Used to exercise respawn-failure containment.
+#[allow(dead_code)] // Used by some but not all integration test binaries.
+pub fn write_broken_venv_fixture(pkg_dir: &Path) {
+    let venv_dir = pkg_dir.join(".venv");
+    std::fs::create_dir_all(venv_dir.join("bin")).unwrap();
+    // Different content from `write_venv_fixture`'s pyvenv.cfg so the
+    // identity token differs even under an inode/mtime collision.
+    std::fs::write(
+        venv_dir.join("pyvenv.cfg"),
+        "home = /usr/bin\nbroken = marker\n",
+    )
+    .unwrap();
+
+    let script_path = venv_dir.join("bin/pyright-langserver");
+    std::fs::write(&script_path, "#!/bin/sh\nexit 1\n").unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
 // ── ProxyUnderTest ──────────────────────────────────────────────────
 
 /// A running proxy process with LSP framing readers/writers attached.
@@ -192,6 +217,19 @@ impl ProxyUnderTest {
                     "version": 1,
                     "text": text
                 }
+            })),
+        );
+        self.write(&msg).await;
+    }
+
+    /// Send `textDocument/didChange` notification (full-sync single change).
+    #[allow(dead_code)] // Used by some but not all integration test binaries.
+    pub async fn did_change(&mut self, uri: &str, version: i64, text: &str) {
+        let msg = RpcMessage::notification(
+            "textDocument/didChange",
+            Some(serde_json::json!({
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [ { "text": text } ]
             })),
         );
         self.write(&msg).await;

--- a/tests/venv_staleness_test.rs
+++ b/tests/venv_staleness_test.rs
@@ -149,6 +149,165 @@ async fn replaced_venv_triggers_single_backend_respawn() {
     );
 }
 
+/// E2E: a venv replacement whose respawn fails (broken interpreter, e.g.
+/// mid-`uv sync`) must not kill the proxy. The `didChange` forward path is
+/// the trigger here because it used to propagate the spawn error fatally.
+/// The client is notified, subsequent requests get explicit errors, and once
+/// the venv is healthy again the next request respawns and recovers.
+#[tokio::test]
+async fn failed_respawn_is_contained_and_recovers() {
+    let scenario_life1 = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            // dispatch_initialized forwards a 2nd "initialized" to fallback backends
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover life1" } } }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![PackageConfig {
+            name: "pkg".to_string(),
+            scenario: scenario_life1,
+            has_venv: true,
+        }],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    let pkg_dir = root.join("pkg");
+    let mut proxy = ProxyUnderTest::spawn_with_env(
+        temp_dir,
+        root.clone(),
+        &pkg_dir,
+        &[("TYPEMUX_CC_VENV_CHECK_INTERVAL", "1")],
+    );
+
+    let root_uri = support::path_to_uri(&pkg_dir);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file_a = pkg_dir.join("a.py");
+    std::fs::write(&file_a, "a = 1\n").unwrap();
+    let file_a_uri = support::path_to_uri(&file_a);
+    proxy.did_open(&file_a_uri, "a = 1\n").await;
+
+    let hover_params = serde_json::json!({
+        "textDocument": { "uri": &file_a_uri },
+        "position": { "line": 0, "character": 0 }
+    });
+
+    let hover1 = proxy
+        .request("textDocument/hover", hover_params.clone())
+        .await;
+    assert!(hover1.error.is_none());
+    assert_eq!(
+        hover1.result.as_ref().unwrap()["contents"]["value"],
+        "hover life1"
+    );
+
+    // Replace the venv with a broken one: pyvenv.cfg present (new identity)
+    // but the fake pyright-langserver exits immediately, so the respawn's
+    // initialize handshake fails deterministically.
+    std::fs::remove_dir_all(pkg_dir.join(".venv")).unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+    support::write_broken_venv_fixture(&pkg_dir);
+
+    // didChange triggers the staleness check: mismatch -> evict -> respawn
+    // fails. Before the containment fix this terminated the whole proxy.
+    proxy.did_change(&file_a_uri, 2, "a = 2\n").await;
+
+    let replaced = proxy
+        .wait_for_notification("window/showMessage", 5000)
+        .await;
+    let replaced_msg = replaced.params.as_ref().unwrap()["message"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        replaced_msg.contains("replaced"),
+        "first showMessage should announce the replaced venv, got: {replaced_msg}"
+    );
+
+    let failure = proxy
+        .wait_for_notification("window/showMessage", 5000)
+        .await;
+    let failure_msg = failure.params.as_ref().unwrap()["message"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        failure_msg.contains("Failed to start LSP backend"),
+        "second showMessage should report the failed respawn, got: {failure_msg}"
+    );
+
+    // The proxy must still be alive and answering. The venv is still broken,
+    // so the lazy retry (pool-miss spawn) fails and the request gets an
+    // explicit JSON-RPC error — not silence, not a dead proxy.
+    let hover2 = proxy
+        .request("textDocument/hover", hover_params.clone())
+        .await;
+    let error = hover2
+        .error
+        .expect("hover against the broken venv must fail explicitly");
+    assert!(
+        error.message.contains("backend error"),
+        "expected a backend error response, got: {}",
+        error.message
+    );
+
+    // Heal the venv. The next request retries backend creation and recovers.
+    let scenario_life2 = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover life2" } } }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+    support::write_venv_fixture(&pkg_dir, &scenario_life2);
+
+    let hover3 = proxy.request("textDocument/hover", hover_params).await;
+    assert!(
+        hover3.error.is_none(),
+        "hover after healing the venv should succeed, got error: {:?}",
+        hover3.error
+    );
+    assert_eq!(
+        hover3.result.as_ref().unwrap()["contents"]["value"],
+        "hover life2"
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}
+
 /// E2E: a `.venv` whose `pyvenv.cfg` disappears is served during the grace
 /// window (transient `uv sync` gap), then evicted without respawn — strict
 /// mode returns an explicit error instead of silently serving stale results.


### PR DESCRIPTION
## Summary

Fixes the uncontained error path found in the issue-inventory audit: when venv identity tracking detected a replaced `.venv` and the respawn failed (e.g. broken interpreter mid-`uv sync`), the spawn error propagated out of `run()` via the `didChange` / `didOpen` pool-hit paths and **terminated the whole proxy** — LSP lost for every venv in the session, with the old backend already evicted.

## Changes

- `StaleOutcome` gains a `RespawnFailed(ProxyError)` variant; `check_pooled_venv_staleness` catches `spawn_and_insert_backend` errors in the Mismatch arm and returns them as an outcome instead of propagating (`src/proxy/pool_management.rs`)
- `didChange` forward path (`src/proxy/mod.rs`) and `didOpen` pool-hit path (`src/proxy/document.rs`): notify the client via `window/showMessage` and keep running
- `ensure_backend_in_pool` maps `RespawnFailed` to `Err`, flowing into its callers' **existing** containment (JSON-RPC error response for requests, notify for didOpen) — no double notification
- Client-writer errors remain fatal (client gone = exit); only backend-creation errors change behavior
- Recovery needs no new machinery: the pool entry is absent after the failed respawn, so the next request retries via the pool-miss path
- ARCHITECTURE.md: new row in the identity-tracking outcome table

## Tests

New E2E `failed_respawn_is_contained_and_recovers` (broken-shim venv fixture: spawn succeeds, handshake fails deterministically on immediate exit):

1. hover works (life1) → replace `.venv` with a broken one → `didChange` triggers the check
2. client receives the "replaced" info message **and** the "Failed to start LSP backend" error message; proxy stays alive
3. hover against the still-broken venv gets an explicit `backend error` JSON-RPC response
4. heal the venv → next hover respawns and serves from the new backend (life2)

**Regression proof**: ran the new test against the unpatched source (src files stashed) — the proxy died with `Initialize failed: … EOF while reading headers` exactly as described in #92 and the test failed; with the patch it passes.

`make all` (fmt + clippy `-D warnings` + full suite) passes; the two existing staleness tests are unchanged and green.

Closes #92