### PR TITLE
chore: harden agent workflow authorization

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "make lint 2>&1 | head -30"
+            "command": "cargo check --quiet --locked"
           }
         ]
       }

--- a/.claude/skills/plugin-test-cycle/SKILL.md
+++ b/.claude/skills/plugin-test-cycle/SKILL.md
@@ -33,7 +33,35 @@ The binary is at `target/release/typemux-cc`.
 
 Use the `/publish` skill instead, then return here at Step 2.
 
-### Step 2: Clear plugin cache
+### Step 2: Record the test state
+
+Create a resumable state note before changing Claude Code's plugin state. Record:
+
+- repository path, branch, and commit
+- whether the working tree is dirty
+- test mode (local build or GitHub release)
+- `target/release/typemux-cc --version`
+- `shasum -a 256 target/release/typemux-cc`
+- expected marketplace source and plugin version
+- each completed workflow step and its result
+
+Store the note outside the repository, for example at
+`/tmp/typemux-cc-plugin-test-state.md`, so it survives a restart without adding an
+untracked project file. Never record credentials or environment variable values.
+
+### Step 3: Approve plugin state changes
+
+Cache deletion, marketplace registration changes, and plugin installation mutate the
+user's Claude Code environment. Show the exact cache path, marketplace registration,
+plugin identity, and commands that will be affected, then obtain explicit user approval
+before each mutation. Approval for one mutation does not authorize another.
+
+Use a dedicated local-development marketplace registration instead of replacing a
+release registration when the installed Claude Code version supports naming separate
+registrations. If it does not, report the limitation and ask before modifying the
+existing `typemux-cc-marketplace` registration. Do not guess unsupported command flags.
+
+### Step 4: Clear plugin cache
 
 This is **critical**. Claude Code caches plugin binaries aggressively. Skipping this step means the old binary gets used silently.
 
@@ -41,15 +69,18 @@ This is **critical**. Claude Code caches plugin binaries aggressively. Skipping 
 rm -rf ~/.claude/plugins/cache/typemux-cc-marketplace/
 ```
 
-### Step 3: Remove old marketplace registration
+Resolve and display the target first, and refuse to delete a path outside
+`~/.claude/plugins/cache/`. Record completion in the state note.
+
+### Step 5: Remove old marketplace registration
 
 ```
 /plugin marketplace remove typemux-cc-marketplace
 ```
 
-If this fails with "not found", that's fine — proceed to Step 4.
+If this fails with "not found", record that result and proceed.
 
-### Step 4: Register marketplace
+### Step 6: Register marketplace
 
 **For local development (no GitHub release needed):**
 
@@ -65,7 +96,7 @@ Use the actual project directory path (or worktree path if working in a worktree
 /plugin marketplace add K-dash/typemux-cc
 ```
 
-### Step 5: Install the plugin
+### Step 7: Install the plugin
 
 ```
 /plugin install typemux-cc@typemux-cc-marketplace
@@ -77,13 +108,23 @@ Verify the plugin appears in the installed list. If it doesn't show up:
 2. Try removing and re-adding the marketplace
 3. Check that `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` are valid JSON
 
-### Step 6: Restart Claude Code
+Before restart, record the installed plugin version and expected binary SHA-256 in the
+state note. Do not assume installation proves which binary will be loaded.
+
+### Step 8: Restart Claude Code
 
 The plugin binary is loaded at startup. A restart is required after installation or update.
 
 Tell the user: "Please restart Claude Code, then come back and say 'continue test' to proceed with verification."
 
-### Step 7: Verify functionality
+After restart, read the state note and confirm that the repository commit, expected
+plugin version, and expected binary hash still identify the intended test artifact.
+Verify the loaded plugin version using the version information exposed by the installed
+plugin. If the loaded binary path can be identified from the installed plugin metadata,
+compare its SHA-256 with the recorded hash. If it cannot be identified, report that the
+binary identity is unverified rather than treating the test as successful.
+
+### Step 9: Verify functionality
 
 After restart, run these LSP operations to verify the plugin works:
 
@@ -101,7 +142,7 @@ After restart, run these LSP operations to verify the plugin works:
    - Open a file in a project without `.venv/`
    - Verify an appropriate error is returned (not stale results)
 
-### Step 8: Check logs
+### Step 10: Check logs
 
 ```bash
 cat /tmp/typemux-cc.log
@@ -114,16 +155,17 @@ Look for:
 - Backend startup/shutdown messages if testing pool behavior
 - `Discarding stale response` if testing race conditions
 
-If the log file doesn't exist, check that log output is configured (via `TYPEMUX_LOG` env var or config).
+If the log file doesn't exist, check that log output is configured via the
+`TYPEMUX_CC_LOG_FILE` environment variable.
 
 ## Common Issues
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Old behavior after update | Plugin cache not cleared | Step 2: `rm -rf ~/.claude/plugins/cache/typemux-cc-marketplace/` |
-| Plugin not in installed list | Marketplace registration stale | Steps 3-4: Remove and re-add marketplace |
-| LSP errors after install | Claude Code not restarted | Step 6: Restart required |
-| No log file at `/tmp/` | Log output not configured | Check config or `TYPEMUX_LOG` environment variable |
+| Old behavior after update | Plugin cache not cleared | Step 4: clear the approved cache path |
+| Plugin not in installed list | Marketplace registration stale | Steps 5-6: remove and re-add the approved marketplace |
+| LSP errors after install | Claude Code not restarted | Step 8: restart required |
+| No log file at `/tmp/` | Log output not configured | Check `TYPEMUX_CC_LOG_FILE` |
 | `cp` prompts for overwrite | Missing `-f` flag | Always use `cp -f` or `rm -f` before copy |
 
 ## Examples
@@ -134,13 +176,14 @@ If the log file doesn't exist, check that log output is configured (via `TYPEMUX
 User: "plugin test"
 Flow:
 1. cargo build --release
-2. rm -rf ~/.claude/plugins/cache/typemux-cc-marketplace/
-3. /plugin marketplace remove typemux-cc-marketplace
-4. /plugin marketplace add /path/to/typemux-cc
-5. /plugin install typemux-cc@typemux-cc-marketplace
-6. [User restarts Claude Code]
-7. LSP hover test on Python file
-8. Read /tmp/typemux-cc.log
+2. Record commit, version, binary hash, and expected marketplace in the state note
+3. Obtain approval before clearing the exact cache path
+4. Obtain separate approval before changing marketplace registration
+5. Register the local repository and install the plugin
+6. Record the installed version and expected binary hash
+7. [User restarts Claude Code]
+8. Resume from the state note and verify artifact identity
+9. Run the LSP hover test and inspect `/tmp/typemux-cc.log`
 ```
 
 ### Example 2: Testing a GitHub release
@@ -149,11 +192,12 @@ Flow:
 User: "test the new release"
 Flow:
 1. (Assumes /publish already done)
-2. rm -rf ~/.claude/plugins/cache/typemux-cc-marketplace/
-3. /plugin marketplace remove typemux-cc-marketplace
-4. /plugin marketplace add K-dash/typemux-cc
-5. /plugin install typemux-cc@typemux-cc-marketplace
+2. Record the release version, source, and expected binary hash in the state note
+3. Obtain approval before clearing the exact cache path
+4. Obtain separate approval before changing marketplace registration
+5. Register `K-dash/typemux-cc` and install the plugin
 6. [User restarts Claude Code]
-7. Full verification: hover + cross-project + missing venv
-8. cat /tmp/typemux-cc.log
+7. Resume from the state note and verify artifact identity
+8. Run hover, cross-project, and missing-venv verification
+9. Inspect `/tmp/typemux-cc.log`
 ```

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: publish
-description: Bump version, tag, and push to trigger the automated release pipeline. Triggers on 'publish', 'release', 'bump version'. This skill handles the full version bump workflow and knows the CI/CD pipeline to avoid manual mistakes.
+description: Prepare and publish a version through a feature branch, pull request, and approved tag push. Triggers on 'publish', 'release', 'bump version'.
 ---
 
 # Publish
@@ -29,12 +29,13 @@ Version must be updated in **3 files** (all must match):
 ### Step 1: Pre-flight checks
 
 ```bash
-git branch --show-current   # Must be on main
+git branch --show-current   # Must not be main when files are changed
 git status                  # Must be clean
 git fetch --tags --quiet
 ```
 
-Confirm clean working directory on `main`. Show the latest tag and current `Cargo.toml` version.
+Show the latest tag and current `Cargo.toml` version. If currently on `main`, create a
+release preparation branch before changing files.
 
 ### Step 2: Ask for the new version
 
@@ -49,17 +50,42 @@ Use AskUserQuestion. Show the current version and suggest semver options (patch,
 2. Run `cargo check --quiet` to regenerate `Cargo.lock`.
 3. Show `git diff` for user review.
 
-### Step 4: Commit, tag, and push
+### Step 4: Prepare a pull request
+
+Ask for explicit authorization before each of the following actions. Authorization for
+one action does not authorize the next one.
 
 ```bash
 git add Cargo.toml Cargo.lock .claude-plugin/plugin.json .claude-plugin/marketplace.json
 git commit -m "chore: bump version to <NEW_VERSION>"
-git tag v<NEW_VERSION>
-git push origin main
+git push -u origin <release-branch>
+gh pr create
+```
+
+Do not tag the feature branch. Wait for the pull request to pass its required checks and
+be merged through the repository's normal merge process. Do not merge it unless the
+user explicitly authorizes the merge.
+
+### Step 5: Tag the merged commit
+
+After the pull request is merged:
+
+1. Fetch the updated `main` and tags.
+2. Verify that the local target commit is the merged `main` commit and that all version
+   locations contain `<NEW_VERSION>`.
+3. Show the exact commit that will be tagged.
+4. Ask for explicit authorization to create the tag.
+5. Create `v<NEW_VERSION>` on that commit.
+6. Ask separately for explicit authorization to push the tag.
+
+```bash
+git tag v<NEW_VERSION> <MERGED_COMMIT>
 git push origin v<NEW_VERSION>
 ```
 
-### Step 5: Verify
+Never commit or push directly to `main`.
 
-Inform the user the CI pipeline will build and create the GitHub Release. Link to:
+### Step 6: Verify
+
+Verify that the CI pipeline builds all release assets and creates the GitHub Release. Link to:
 `https://github.com/K-dash/typemux-cc/actions`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,15 @@
 
 **WORKFLOW:**
 
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
-2. **Run quality gates** (if code changed) - `make all`
-3. **Commit changes** - Conventional commits on feature branch
-4. **Ask user about push** - Confirm before pushing to remote
-5. **Hand off** - Provide context for next session
+1. **Run quality gates** (if code changed) - `make all`
+2. **Report remaining work** - Describe follow-up work without creating issues unless the user explicitly authorizes issue creation
+3. **Report the working tree** - Summarize changed files and verification results
+4. **Hand off** - Provide context for the next session
+
+Creating issues, committing, pushing, and opening pull requests are separate external
+mutations. Perform each one only when the user explicitly authorizes that action. An
+instruction to commit does not authorize a push or pull request, and an instruction to
+push does not authorize opening a pull request.
 
 ---
 
@@ -44,10 +48,13 @@ make test         # cargo test
    make all  # format + lint + test
    ```
 3. **Update documentation**: If user-facing behavior changes, update README.md
-4. **Commit**: Use conventional commits (feat:, fix:, docs:, etc.)
-5. **Push and create PR**: Never merge directly to main
+4. **Commit, when explicitly authorized**: Use conventional commits (feat:, fix:, docs:, etc.)
+5. **Push, when explicitly authorized**: Never merge directly to main
    ```bash
    git push -u origin <branch-name>
+   ```
+6. **Create a pull request, when explicitly authorized**
+   ```bash
    gh pr create
    ```
 
@@ -57,13 +64,14 @@ Before committing, verify:
 - [ ] On a feature branch (not main)?
 - [ ] `make all` passes?
 - [ ] README.md updated if needed?
-- [ ] PR will be created?
+- [ ] The user explicitly authorized the commit?
 
 ## Instructions for AI Agents
 
 - **All code comments, commit messages, PR titles, PR descriptions, and review comments MUST be written in English.** No exceptions.
 - Before committing, ALWAYS re-read this Workflow section
 - When user says "commit", first check current branch and create feature branch if on main
+- Treat authorization for issue creation, commits, pushes, and pull requests separately; never infer one from another
 - When user-facing behavior changes, proactively update README.md before committing
 - **No implicit fallbacks** — Never add silent fallback logic that masks errors. Let it fail loudly so unintended behavior is caught early. An explicit error is always better than a silent wrong result.
 - **No backward compatibility** — Do not preserve backward compatibility unless the user explicitly requests it. Breaking changes are the default; do not add compatibility shims, re-exports, or deprecation wrappers.
@@ -107,4 +115,3 @@ See @docs/ARCHITECTURE.md for source code structure.
 ## Known Mistakes & Lessons Learned
 
 <!-- Reverse-chronological. Format: ### YYYY-MM-DD: Description / What happened / Root cause / Rule -->
-


### PR DESCRIPTION
## Summary

- require explicit authorization for issue creation, commits, pushes, pull requests, merges, and release tags
- move the publish workflow to a feature branch and pull request before tagging the merged commit
- make the local plugin test cycle resumable and guard destructive cache and marketplace mutations
- replace the lossy post-edit lint pipeline with a non-mutating locked cargo check

## Verification

- `git diff --check`
- `.claude/settings.json` validated with `jq`
- `make ci`

This is the first PR in the non-functional hardening series.