### PR TITLE
ci: make release publishing atomic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,46 @@
 name: Release
 
+# Releases are atomic: validate -> build all platforms -> publish once.
+# `publish` needs the full `build` matrix, and a `needs:` dependency on a
+# matrix job is only satisfied when every leg succeeds. So if any platform
+# build fails, `publish` never runs and no GitHub Release is created —
+# there is no window where a Release exists with missing or partial assets.
+
 on:
   push:
     tags:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  # Create the release (with generated notes) exactly once, before any
-  # build job touches it. Running generate_release_notes from each matrix
-  # job appends another copy of the notes on every update, duplicating
-  # the "What's Changed" section.
-  create-release:
-    name: Create release
+  validate:
+    name: Validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 20
     steps:
-      - name: Create GitHub release with generated notes
-        uses: softprops/action-gh-release@v3
-        with:
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run quality gate
+        run: make ci
 
   build:
     name: Build ${{ matrix.target }}
-    needs: create-release
+    needs: validate
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    timeout-minutes: 30
     strategy:
       matrix:
         include:
@@ -69,11 +82,41 @@ jobs:
       - name: Generate checksum
         run: shasum -a 256 ${{ matrix.binary_name }} > ${{ matrix.binary_name }}.sha256
 
-      - name: Upload to release
-        uses: softprops/action-gh-release@v3
+      # Upload as a build artifact instead of attaching to a release directly:
+      # the release itself is only ever created once, by `publish`, after
+      # every matrix leg here has succeeded.
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
         with:
-          files: |
+          name: ${{ matrix.binary_name }}
+          path: |
             ${{ matrix.binary_name }}
             ${{ matrix.binary_name }}.sha256
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    timeout-minutes: 15
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      # Create the release exactly once, with every asset attached and
+      # generated notes. Doing this in a single job also avoids the
+      # duplicated "What's Changed" section that appeared when notes were
+      # generated repeatedly across matrix legs.
+      - name: Create GitHub release with all assets
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+          files: artifacts/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Restructure `.github/workflows/release.yml` from `create-release -> build` into `validate -> build (matrix) -> publish`.
- A GitHub Release is now created **exactly once**, in the final `publish` job, only after `make ci` passes and every platform build succeeds. A failed build leg can no longer leave a public Release with missing or partial assets.
- `build` jobs now upload the binary + `.sha256` as a GitHub Actions artifact (`actions/upload-artifact@v4`, `if-no-files-found: error`) instead of attaching directly to a release. `publish` downloads all artifacts (`actions/download-artifact@v4`, `merge-multiple: true`) and creates the release with `generate_release_notes: true` and all assets in one step.
- Each job declares its own least-privilege `permissions` and a `timeout-minutes`; `contents: write` is granted only to `publish` (top-level default is now `contents: read`).
- Release asset names (`typemux-cc-macos-arm64`, `typemux-cc-linux-x86_64`, `typemux-cc-linux-arm64`, and their `.sha256`) are unchanged — verified against `install.sh`'s `BINARY_NAME`/`DOWNLOAD_URL` logic.

## Why atomic

`needs: build` on a job that depends on a **matrix** job only resolves once every matrix leg succeeds (default `fail-fast: true`); if any leg fails, dependent jobs are skipped. Since `publish` is the only job that touches the Release, a build failure now produces no Release at all, instead of a partial one.

## Out of scope (deferred to a follow-up PR)

- Tag/version consistency check against `plugin.json`.
- Pinning actions to commit SHAs.

## Job dependency graph

```
validate (make ci, ubuntu-latest)
   |
   v
build (matrix: macos-arm64 / linux-x86_64 / linux-arm64)  -- needs ALL legs to pass
   |
   v
publish (download artifacts, create release once)  -- only runs if build succeeded entirely
```

## Test plan

- [x] `actionlint .github/workflows/release.yml` — passes (exit 0), locally installed v1.7.12.
- [x] YAML syntax validated (`ruby -ryaml`, since PyYAML wasn't available locally).
- [x] `make ci` (fmt-check + lint + doc + test) — all green, no Rust source changed.
- [x] `git diff --check` — no whitespace issues.
- [x] Manually cross-checked each `binary_name` / `.sha256` against `install.sh`'s asset name and `DOWNLOAD_URL` expectations — unchanged.
- [x] Manually traced that the only release-creating step lives in `publish`, and `publish` is unreachable unless `validate` and every `build` leg succeed.
- [ ] Not verified: an actual tag-push release run end-to-end (would require pushing a `v*` tag, out of scope for this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)