### PR TITLE
fix: fail startup on invalid timeout/interval env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ Settings priority: **CLI flag > environment variable > config file > default**
 | `TYPEMUX_CC_VENV_CHECK_INTERVAL` | Interval in seconds between venv identity checks (0 = disable venv identity tracking) | `5` |
 | `RUST_LOG` | Log level | `typemux_cc=debug` |
 
+An invalid value for a numeric variable above (e.g. `TYPEMUX_CC_FANOUT_TIMEOUT=5s`) fails startup with an explicit error instead of silently falling back to the default.
+
 ## Typical Use Case
 
 ### Git Worktree (AI-Assisted Development)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -181,6 +181,7 @@ pub enum WarmupState {
 |---------|---------|-------------|
 | `TYPEMUX_CC_WARMUP_TIMEOUT` | `2` (seconds) | Warmup timeout duration |
 | `TYPEMUX_CC_WARMUP_TIMEOUT=0` | — | Disable warmup entirely (immediate Ready) |
+| `TYPEMUX_CC_WARMUP_TIMEOUT=<non-integer>` | — | Startup fails with an explicit error |
 
 ## Strict Venv Mode
 
@@ -235,7 +236,8 @@ mtime/size.
 ### Check Triggers and Outcomes
 
 Checks are debounced to once per `TYPEMUX_CC_VENV_CHECK_INTERVAL` seconds
-(default 5; `0` disables tracking). Triggers: `ensure_backend_in_pool`
+(default 5; `0` disables tracking; a non-integer value fails startup with an
+explicit error). Triggers: `ensure_backend_in_pool`
 (all venv-checked request methods), `didOpen`/`didChange` forwarding, and a
 60s background sweep (shared with the TTL timer, armed even when TTL is
 disabled).
@@ -292,7 +294,7 @@ Results are deduplicated using the key: `(uri, range.start.line, range.start.cha
 
 ### Timeout and Partial Results
 
-If a backend does not respond within the fan-out timeout (default 5s, configurable via `TYPEMUX_CC_FANOUT_TIMEOUT`):
+If a backend does not respond within the fan-out timeout (default 5s, configurable via `TYPEMUX_CC_FANOUT_TIMEOUT`; a non-integer value fails startup with an explicit error):
 
 1. A `window/showMessage` warning is sent to the client listing timed-out backends
 2. `$/cancelRequest` is sent to remaining backends (best effort)

--- a/src/backend_pool.rs
+++ b/src/backend_pool.rs
@@ -26,6 +26,12 @@ const DEFAULT_WARMUP_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Returns the warmup timeout duration.
 /// `TYPEMUX_CC_WARMUP_TIMEOUT=0` means warmup is disabled (immediate Ready).
+///
+/// The `.ok()` below only ever swallows an "unset" case: `validate_env_config`
+/// runs at startup and aborts on an unparseable value, so by the time this is
+/// called on the normal startup path, a set value is guaranteed to parse.
+/// (`--doctor` skips that validation and calls this directly; it reports raw
+/// invalid values itself instead of relying on this fallback.)
 pub fn warmup_timeout() -> Duration {
     std::env::var("TYPEMUX_CC_WARMUP_TIMEOUT")
         .ok()
@@ -38,6 +44,9 @@ const DEFAULT_FANOUT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Returns the fan-out timeout duration for workspace/symbol and similar multi-backend requests.
 /// `TYPEMUX_CC_FANOUT_TIMEOUT=0` means no timeout (wait forever).
+///
+/// See `warmup_timeout`'s doc comment: reachable only with an unset or
+/// already-validated value on the normal startup path.
 pub fn fanout_timeout() -> Duration {
     std::env::var("TYPEMUX_CC_FANOUT_TIMEOUT")
         .ok()
@@ -51,11 +60,40 @@ const DEFAULT_VENV_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Returns the debounce interval for pooled-backend venv identity checks.
 /// `TYPEMUX_CC_VENV_CHECK_INTERVAL=0` disables venv identity tracking entirely.
+///
+/// See `warmup_timeout`'s doc comment: reachable only with an unset or
+/// already-validated value on the normal startup path.
 pub fn venv_check_interval() -> Duration {
     std::env::var("TYPEMUX_CC_VENV_CHECK_INTERVAL")
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
         .map_or(DEFAULT_VENV_CHECK_INTERVAL, Duration::from_secs)
+}
+
+/// Env vars validated by `validate_env_config`, backing the three accessors above.
+const TIMEOUT_ENV_VARS: [&str; 3] = [
+    "TYPEMUX_CC_WARMUP_TIMEOUT",
+    "TYPEMUX_CC_FANOUT_TIMEOUT",
+    "TYPEMUX_CC_VENV_CHECK_INTERVAL",
+];
+
+/// Validates the timeout/interval env vars above at startup, before the event
+/// loop runs. A set-but-unparseable value (e.g. `TYPEMUX_CC_FANOUT_TIMEOUT=5s`)
+/// is a configuration error, not something to silently default around, so this
+/// returns an error naming the variable and its raw value instead of letting
+/// the accessors swallow it via `.ok()`. Not called for `--doctor`, which
+/// reports invalid values instead of aborting.
+pub fn validate_env_config() -> Result<(), String> {
+    for env_var in TIMEOUT_ENV_VARS {
+        if let Ok(raw) = std::env::var(env_var) {
+            if raw.parse::<u64>().is_err() {
+                return Err(format!(
+                    "invalid {env_var}={raw:?}: expected a non-negative integer number of seconds"
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Message from a backend reader task

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -100,6 +100,38 @@ fn env_only_source(env_var: &str, config_report: &ConfigLoadReport) -> String {
     }
 }
 
+/// Build the config item for one of the timeout/interval settings validated by
+/// `backend_pool::validate_env_config`. `--doctor` bypasses that validation
+/// (see `main.rs`), so an invalid value never aborts here; instead this shows
+/// the raw value and marks it invalid rather than reporting the accessor's
+/// silent default fallback as if it were in effect.
+fn timeout_env_item(
+    name: &str,
+    env_var: &str,
+    effective: std::time::Duration,
+    config_report: &ConfigLoadReport,
+) -> ConfigItem {
+    let raw = std::env::var(env_var);
+    let source = env_only_source(env_var, config_report);
+    match raw {
+        Err(_) => ConfigItem {
+            name: name.to_string(),
+            value: effective.as_secs().to_string(),
+            source,
+        },
+        Ok(raw) if raw.parse::<u64>().is_ok() => ConfigItem {
+            name: name.to_string(),
+            value: effective.as_secs().to_string(),
+            source,
+        },
+        Ok(raw) => ConfigItem {
+            name: name.to_string(),
+            value: format!("{raw:?} (invalid)"),
+            source: format!("{source} (invalid, would fail to start)"),
+        },
+    }
+}
+
 /// Search for a binary in PATH directories using `std::env::split_paths` + metadata.
 /// Returns the first match that is a file with execute permission.
 pub fn find_binary_in_path(binary_name: &str) -> Option<PathBuf> {
@@ -209,26 +241,26 @@ pub async fn collect_doctor_report(
         source: arg_source(matches, "backend_ttl", config_report),
     };
 
-    let warmup_timeout = backend_pool::warmup_timeout();
-    let warmup_timeout_item = ConfigItem {
-        name: "warmup_timeout".to_string(),
-        value: warmup_timeout.as_secs().to_string(),
-        source: env_only_source("TYPEMUX_CC_WARMUP_TIMEOUT", config_report),
-    };
+    let warmup_timeout_item = timeout_env_item(
+        "warmup_timeout",
+        "TYPEMUX_CC_WARMUP_TIMEOUT",
+        backend_pool::warmup_timeout(),
+        config_report,
+    );
 
-    let fanout_timeout = backend_pool::fanout_timeout();
-    let fanout_timeout_item = ConfigItem {
-        name: "fanout_timeout".to_string(),
-        value: fanout_timeout.as_secs().to_string(),
-        source: env_only_source("TYPEMUX_CC_FANOUT_TIMEOUT", config_report),
-    };
+    let fanout_timeout_item = timeout_env_item(
+        "fanout_timeout",
+        "TYPEMUX_CC_FANOUT_TIMEOUT",
+        backend_pool::fanout_timeout(),
+        config_report,
+    );
 
-    let venv_check_interval = backend_pool::venv_check_interval();
-    let venv_check_interval_item = ConfigItem {
-        name: "venv_check_interval".to_string(),
-        value: venv_check_interval.as_secs().to_string(),
-        source: env_only_source("TYPEMUX_CC_VENV_CHECK_INTERVAL", config_report),
-    };
+    let venv_check_interval_item = timeout_env_item(
+        "venv_check_interval",
+        "TYPEMUX_CC_VENV_CHECK_INTERVAL",
+        backend_pool::venv_check_interval(),
+        config_report,
+    );
 
     let log_file_value: String = matches
         .get_one::<PathBuf>("log_file")

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,12 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    // Fail loudly on unparseable timeout/interval env vars before starting
+    // anything else (see `validate_env_config` doc comment).
+    if let Err(msg) = backend_pool::validate_env_config() {
+        anyhow::bail!(msg);
+    }
+
     // Initialize logging (default: stderr, --log-file adds file output)
     if let Some(log_path) = &args.log_file {
         // File output specified: stderr + file

--- a/tests/env_config_test.rs
+++ b/tests/env_config_test.rs
@@ -1,0 +1,100 @@
+//! Startup validation for the timeout/interval env vars in `backend_pool.rs`.
+//!
+//! Unlike `TYPEMUX_CC_BACKEND`/`TYPEMUX_CC_MAX_BACKENDS`/etc., which go through
+//! clap and already abort on invalid values, these three used to swallow parse
+//! failures via `.ok()` and silently fall back to the default (issue #102).
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn invalid_warmup_timeout_fails_startup() {
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.env("TYPEMUX_CC_WARMUP_TIMEOUT", "abc");
+
+    cmd.assert().failure().stderr(
+        predicate::str::contains("TYPEMUX_CC_WARMUP_TIMEOUT").and(predicate::str::contains("abc")),
+    );
+}
+
+#[test]
+fn invalid_fanout_timeout_fails_startup() {
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.env("TYPEMUX_CC_FANOUT_TIMEOUT", "5s");
+
+    cmd.assert().failure().stderr(
+        predicate::str::contains("TYPEMUX_CC_FANOUT_TIMEOUT").and(predicate::str::contains("5s")),
+    );
+}
+
+#[test]
+fn invalid_venv_check_interval_fails_startup() {
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.env("TYPEMUX_CC_VENV_CHECK_INTERVAL", "-1");
+
+    cmd.assert().failure().stderr(
+        predicate::str::contains("TYPEMUX_CC_VENV_CHECK_INTERVAL")
+            .and(predicate::str::contains("-1")),
+    );
+}
+
+#[test]
+fn doctor_reports_invalid_env_value_distinctly() {
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.arg("--doctor").env("TYPEMUX_CC_WARMUP_TIMEOUT", "abc");
+
+    // --doctor must not abort on an invalid value; it should surface the raw
+    // value and mark it invalid instead of reporting the silent default.
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\"abc\" (invalid)"))
+        .stdout(predicate::str::contains(
+            "env: TYPEMUX_CC_WARMUP_TIMEOUT (invalid",
+        ));
+}
+
+#[test]
+fn doctor_distinguishes_default_valid_and_invalid_env_values() {
+    // default: unset
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.arg("--doctor").arg("--json");
+    let default_output = cmd.output().expect("failed to run");
+    assert!(default_output.status.success());
+    let default_json: serde_json::Value = serde_json::from_slice(&default_output.stdout).unwrap();
+    let default_item = find_config_item(&default_json, "fanout_timeout");
+    assert_eq!(default_item["source"], "default");
+    assert_eq!(default_item["value"], "5");
+
+    // valid env value
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.arg("--doctor")
+        .arg("--json")
+        .env("TYPEMUX_CC_FANOUT_TIMEOUT", "9");
+    let valid_output = cmd.output().expect("failed to run");
+    assert!(valid_output.status.success());
+    let valid_json: serde_json::Value = serde_json::from_slice(&valid_output.stdout).unwrap();
+    let valid_item = find_config_item(&valid_json, "fanout_timeout");
+    assert_eq!(valid_item["source"], "env: TYPEMUX_CC_FANOUT_TIMEOUT");
+    assert_eq!(valid_item["value"], "9");
+
+    // invalid env value
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.arg("--doctor")
+        .arg("--json")
+        .env("TYPEMUX_CC_FANOUT_TIMEOUT", "5s");
+    let invalid_output = cmd.output().expect("failed to run");
+    assert!(invalid_output.status.success());
+    let invalid_json: serde_json::Value = serde_json::from_slice(&invalid_output.stdout).unwrap();
+    let invalid_item = find_config_item(&invalid_json, "fanout_timeout");
+    assert!(invalid_item["source"].as_str().unwrap().contains("invalid"));
+    assert!(invalid_item["value"].as_str().unwrap().contains("5s"));
+}
+
+fn find_config_item<'a>(report: &'a serde_json::Value, name: &str) -> &'a serde_json::Value {
+    report["configuration"]["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["name"] == name)
+        .unwrap_or_else(|| panic!("no config item named {name}"))
+}


### PR DESCRIPTION
TYPEMUX_CC_WARMUP_TIMEOUT, TYPEMUX_CC_FANOUT_TIMEOUT, and TYPEMUX_CC_VENV_CHECK_INTERVAL silently ignored unparseable values via `.ok()` and fell back to their defaults, contradicting the explicit-errors principle and the behavior of the other clap-backed env vars.

Add backend_pool::validate_env_config, called at startup before the event loop (but not for --doctor), which aborts with the variable name and raw value on a parse failure. The three accessors keep their existing `.ok()` fallback, now documented as unreachable on the validated startup path.

--doctor no longer reports an invalid value as if the default were in effect: it shows the raw value and marks it invalid, distinguishing default/valid/invalid sources instead of just "set or not".

Skips the clap migration proposed in #102 to keep the diff minimal (many call sites read these accessors directly rather than through clap args).

Closes #102