### PR TITLE
fix: bound warmup queue to prevent unbounded memory growth

### DIFF
--- a/src/backend_pool.rs
+++ b/src/backend_pool.rs
@@ -21,6 +21,15 @@ pub enum WarmupState {
     Ready,
 }
 
+/// Maximum number of index-dependent requests queued per backend during
+/// warmup. Not configurable: a fixed ceiling is enough to bound memory growth
+/// without adding another env var to the surface.
+pub const MAX_WARMUP_QUEUE_LEN: usize = 64;
+
+/// Queue length at which `try_queue_warmup_request` logs a one-time
+/// approaching-capacity warning.
+const WARMUP_QUEUE_WARN_THRESHOLD: usize = MAX_WARMUP_QUEUE_LEN * 4 / 5;
+
 /// Default warmup timeout; overridable via `TYPEMUX_CC_WARMUP_TIMEOUT` env var.
 const DEFAULT_WARMUP_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -143,6 +152,26 @@ impl BackendInstance {
     /// Check if the warmup deadline has passed
     pub fn warmup_expired(&self) -> bool {
         Instant::now() >= self.warmup_deadline
+    }
+
+    /// Queue an index-dependent request during warmup, unless the queue is
+    /// already at `MAX_WARMUP_QUEUE_LEN`. Returns `false` if the request was
+    /// rejected for capacity, in which case the caller must send an error
+    /// response instead of queueing.
+    pub fn try_queue_warmup_request(&mut self, msg: RpcMessage) -> bool {
+        if self.warmup_queue.len() >= MAX_WARMUP_QUEUE_LEN {
+            return false;
+        }
+        self.warmup_queue.push(msg);
+        if self.warmup_queue.len() == WARMUP_QUEUE_WARN_THRESHOLD {
+            tracing::warn!(
+                venv = %self.venv_path.display(),
+                queue_len = self.warmup_queue.len(),
+                max = MAX_WARMUP_QUEUE_LEN,
+                "Warmup queue approaching capacity"
+            );
+        }
+        true
     }
 
     /// Remove a queued request by its JSON-RPC id (for $/cancelRequest handling).

--- a/src/proxy/client_dispatch.rs
+++ b/src/proxy/client_dispatch.rs
@@ -1,5 +1,5 @@
 use crate::backend::LspBackend;
-use crate::backend_pool::{shutdown_backend_instance, BackendInstance};
+use crate::backend_pool::{shutdown_backend_instance, BackendInstance, MAX_WARMUP_QUEUE_LEN};
 use crate::error::ProxyError;
 use crate::framing::LspFrameWriter;
 use crate::message::{RpcId, RpcMessage};
@@ -300,6 +300,36 @@ impl super::LspProxy {
 
             if let Some((session, should_queue)) = backend_info {
                 if should_queue {
+                    let queued = self
+                        .state
+                        .pool
+                        .get_mut(venv_path)
+                        .is_some_and(|inst| inst.try_queue_warmup_request(msg.clone()));
+
+                    if !queued {
+                        let queue_len = self
+                            .state
+                            .pool
+                            .get(venv_path)
+                            .map_or(0, |inst| inst.warmup_queue.len());
+                        tracing::warn!(
+                            method = ?method,
+                            id = ?msg.id,
+                            venv = %venv_path.display(),
+                            queue_len,
+                            "Rejecting index-dependent request: warmup queue full"
+                        );
+                        let error_response = RpcMessage::error_response(
+                            msg,
+                            &format!(
+                                "lsp-proxy: warmup queue full ({MAX_WARMUP_QUEUE_LEN} requests) for {}",
+                                venv_path.display()
+                            ),
+                        );
+                        client_writer.write_message(&error_response).await?;
+                        return Ok(());
+                    }
+
                     // Register in pending requests (so cancel/crash handling works)
                     self.register_pending_request(msg, session, venv_path);
                     tracing::info!(
@@ -308,9 +338,6 @@ impl super::LspProxy {
                         venv = %venv_path.display(),
                         "Queueing index-dependent request during warmup"
                     );
-                    if let Some(inst) = self.state.pool.get_mut(venv_path) {
-                        inst.warmup_queue.push(msg.clone());
-                    }
                     return Ok(());
                 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -235,6 +235,17 @@ impl ProxyUnderTest {
         self.write(&msg).await;
     }
 
+    /// Send a request without waiting for its response. Returns the assigned
+    /// id, for matching against a later `read_next`.
+    #[allow(dead_code)] // Used by some but not all integration test binaries.
+    pub async fn send_request(&mut self, method: &str, params: Value) -> i64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        let msg = RpcMessage::request(RpcId::Number(id), method, Some(params));
+        self.write(&msg).await;
+        id
+    }
+
     /// Send a request and wait for the response (with timeout).
     pub async fn request(&mut self, method: &str, params: Value) -> RpcMessage {
         let id = self.next_id;

--- a/tests/warmup_queue_limit_test.rs
+++ b/tests/warmup_queue_limit_test.rs
@@ -1,0 +1,104 @@
+mod support;
+
+use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
+use typemux_cc::message::RpcId;
+
+/// Mirrors `MAX_WARMUP_QUEUE_LEN` in `src/backend_pool.rs`. Not exported from
+/// the lib crate (the E2E harness only links `framing`/`message` and drives
+/// the proxy as a black-box subprocess), so it is duplicated here.
+const MAX_WARMUP_QUEUE_LEN: usize = 64;
+
+/// E2E: once `MAX_WARMUP_QUEUE_LEN` index-dependent requests are queued
+/// during warmup, the next one is rejected immediately with a JSON-RPC error
+/// instead of being queued.
+///
+/// The backend never sends a `$/progress` end event and the warmup timeout
+/// is set far beyond the test's runtime, so the backend stays `Warming` for
+/// the whole test — the queue can only shrink via the capacity rejection
+/// under test, never via drain.
+#[tokio::test]
+async fn warmup_queue_rejects_once_full() {
+    let scenario = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "definitionProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            // dispatch_initialized forwards a 2nd "initialized" to fallback backends
+            { "expect": { "method": "initialized" }, "actions": [] }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![PackageConfig {
+            name: "pkg".to_string(),
+            scenario,
+            has_venv: true,
+        }],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    // Start proxy from pkg/ (has .venv → backend spawns immediately) with a
+    // warmup timeout far longer than the test, so fail-open never kicks in.
+    // RUST_LOG is pinned so a developer's `~/.config/typemux-cc/config`
+    // (which may set `RUST_LOG=typemux_cc=trace`) can't reintroduce enough
+    // per-request logging overhead to blow the harness's 5s read timeout
+    // across MAX_WARMUP_QUEUE_LEN back-to-back requests.
+    let mut proxy = ProxyUnderTest::spawn_with_env(
+        temp_dir,
+        root.clone(),
+        &root.join("pkg"),
+        &[
+            ("TYPEMUX_CC_WARMUP_TIMEOUT", "600"),
+            ("RUST_LOG", "typemux_cc=warn"),
+        ],
+    );
+
+    let root_uri = support::path_to_uri(&root.join("pkg"));
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file_uri = support::path_to_uri(&root.join("pkg/a.py"));
+    let definition_params = || {
+        serde_json::json!({
+            "textDocument": { "uri": &file_uri },
+            "position": { "line": 0, "character": 0 }
+        })
+    };
+
+    // Fill the warmup queue to capacity. None of these get a response: the
+    // backend never leaves `Warming`, so nothing is ever drained.
+    for _ in 0..MAX_WARMUP_QUEUE_LEN {
+        proxy
+            .send_request("textDocument/definition", definition_params())
+            .await;
+    }
+
+    // The next request overflows the queue and must be rejected immediately.
+    let overflow_id = proxy
+        .send_request("textDocument/definition", definition_params())
+        .await;
+
+    let resp = proxy.read_next().await;
+    assert_eq!(
+        resp.id,
+        Some(RpcId::Number(overflow_id)),
+        "expected an immediate response for the overflowing request, got {resp:?}"
+    );
+    assert!(
+        resp.error.is_some(),
+        "overflowing request should get a JSON-RPC error response, got {resp:?}"
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}


### PR DESCRIPTION
## Summary

`BackendInstance.warmup_queue` had no upper bound. During warmup, index-dependent requests were queued without limit, so a workspace with rapid-fire requests during the warmup window could grow memory unboundedly.

## Changes

- `src/backend_pool.rs`: add `pub const MAX_WARMUP_QUEUE_LEN = 64` and `BackendInstance::try_queue_warmup_request()`. Pushes onto the queue while under capacity, logs a one-time approaching-capacity `tracing::warn!` at 80% (51 entries), and returns `false` once full.
- `src/proxy/client_dispatch.rs`: replace the unconditional `warmup_queue.push` with a call to `try_queue_warmup_request`. On rejection, log `tracing::warn!` (method / id / venv / queue_len) and immediately return a JSON-RPC error response via `RpcMessage::error_response` (`"lsp-proxy: "` prefix), following the existing containment convention used elsewhere in `dispatch_client_request`. `register_pending_request` and the "Queueing" info log now only run on the success path.
- `tests/support/mod.rs`: add a `send_request` helper that fires a request without awaiting its response.
- `tests/warmup_queue_limit_test.rs`: new E2E `warmup_queue_rejects_once_full`. Uses `TYPEMUX_CC_WARMUP_TIMEOUT=600` with a mock scenario that withholds progress-end to keep the backend in `Warming`, fills the queue with 64 `definition` requests, then asserts the 65th is rejected immediately with a JSON-RPC error. `RUST_LOG=typemux_cc=warn` is pinned inside the test so a developer's `~/.config/typemux-cc/config` (which may set a trace-level filter) can't blow the harness's 5s read timeout across back-to-back requests.

## Design notes

- #17 proposed a configurable limit; this uses a fixed const (64) instead, to avoid growing the env var surface and to avoid conflicting with the concurrent env-parsing rework in #102. Configurability can be layered on later if needed.
- The drain paths (progress-end → `Ready` transition, warmup-timeout fail-open) are unchanged.
- Only requests are queued — notifications go through a separate dispatch path and are unaffected by this change (confirmed by code reading).

## Tests

`make all` is green (verified independently by both the implementing subagent and this review pass). Regression confirmed: stashing the `src/` changes and running the new test against the unpatched code, the rejection response never arrives and the test times out after 5s; with the fix applied, it passes.

Closes #17