### PR TITLE
fix: dedupe backend-error showMessage notifications per venv

### DIFF
--- a/src/proxy/diagnostics.rs
+++ b/src/proxy/diagnostics.rs
@@ -3,6 +3,7 @@ use crate::framing::LspFrameWriter;
 use crate::message::RpcMessage;
 use crate::venv;
 use std::path::Path;
+use tokio::time::Instant;
 
 impl super::LspProxy {
     /// Warn the client if a venv's project root is gitignored from the proxy's cwd.
@@ -64,13 +65,32 @@ impl super::LspProxy {
         }
     }
 
-    /// Send window/showMessage error to client when backend creation fails
+    /// Send window/showMessage error to client when backend creation fails.
+    ///
+    /// Logs every failure server-side. The client-visible notification is
+    /// deduplicated per venv within a TTL (see
+    /// `ProxyState::should_notify_backend_failure`) so that repeated
+    /// failures (e.g. `didOpen` for several files under the same broken
+    /// venv) don't spam `window/showMessage` (issue #26).
     pub(crate) async fn notify_backend_error(
-        &self,
+        &mut self,
         venv_path: &Path,
         error: &ProxyError,
         client_writer: &mut LspFrameWriter<tokio::io::Stdout>,
     ) {
+        tracing::error!(
+            venv = %venv_path.display(),
+            error = ?error,
+            "Backend creation failed"
+        );
+
+        if !self
+            .state
+            .should_notify_backend_failure(venv_path, Instant::now())
+        {
+            return;
+        }
+
         let msg = RpcMessage::notification(
             "window/showMessage",
             Some(serde_json::json!({

--- a/src/proxy/pool_management.rs
+++ b/src/proxy/pool_management.rs
@@ -115,6 +115,7 @@ impl super::LspProxy {
 
         let instance = self.create_backend_instance(venv, client_writer).await?;
         self.state.pool.insert(venv.to_path_buf(), instance);
+        self.state.venv_error_notified_at.remove(venv);
         self.warn_if_project_root_ignored(venv, client_writer).await;
 
         Ok(())

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,10 +2,17 @@ use crate::backend::BackendKind;
 use crate::backend_pool::BackendPool;
 use crate::message::{RpcId, RpcMessage};
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::time::Instant;
 use url::Url;
+
+/// TTL for deduplicating client-visible `window/showMessage` notifications
+/// about repeated backend-creation failures for the same venv (issue #26).
+/// Deliberately a plain const rather than an env var: server-side logs are
+/// unaffected by this window, so there is no operator-facing behavior to
+/// tune.
+const NOTIFICATION_DEDUP_TTL: Duration = Duration::from_secs(30);
 
 /// Information about pending requests
 #[derive(Debug, Clone)]
@@ -92,6 +99,11 @@ pub struct ProxyState {
     /// once per venv per proxy lifetime, even if the backend is later
     /// TTL-evicted and respawned).
     pub ignore_checked_venvs: HashSet<PathBuf>,
+
+    /// Last time a client-visible backend-failure notification was sent for
+    /// a venv, keyed by venv path. Used to dedupe `window/showMessage`
+    /// spam when the same venv keeps failing to spawn (issue #26).
+    pub venv_error_notified_at: HashMap<PathBuf, Instant>,
 }
 
 impl ProxyState {
@@ -111,6 +123,7 @@ impl ProxyState {
             pool: BackendPool::new(max_backends, backend_ttl),
             pending_fanouts: HashMap::new(),
             ignore_checked_venvs: HashSet::new(),
+            venv_error_notified_at: HashMap::new(),
         }
     }
 
@@ -129,5 +142,65 @@ impl ProxyState {
             .values()
             .filter_map(|f| f.deadline)
             .min()
+    }
+
+    /// Returns whether a client-visible `window/showMessage` notification
+    /// should be sent for a backend failure in `venv_path` at `now`.
+    /// Records `now` as the last-notified time when it returns `true`.
+    /// Repeated failures for the same venv within `NOTIFICATION_DEDUP_TTL`
+    /// return `false` — callers must still log every failure server-side,
+    /// since this only governs the client-visible notification.
+    pub fn should_notify_backend_failure(&mut self, venv_path: &Path, now: Instant) -> bool {
+        let recently_notified = self
+            .venv_error_notified_at
+            .get(venv_path)
+            .is_some_and(|last| now.duration_since(*last) < NOTIFICATION_DEDUP_TTL);
+        if recently_notified {
+            return false;
+        }
+        self.venv_error_notified_at
+            .insert(venv_path.to_path_buf(), now);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::BackendKind;
+
+    fn test_state() -> ProxyState {
+        ProxyState::new(BackendKind::Pyright, 4, None)
+    }
+
+    #[test]
+    fn should_notify_backend_failure_dedupes_within_ttl() {
+        let mut state = test_state();
+        let venv = PathBuf::from("/tmp/project/.venv");
+        let t0 = Instant::now();
+
+        // First failure: no prior notification, so it should notify.
+        assert!(state.should_notify_backend_failure(&venv, t0));
+
+        // A second failure a few seconds later, still within the TTL,
+        // must be suppressed.
+        assert!(!state.should_notify_backend_failure(&venv, t0 + Duration::from_secs(10)));
+
+        // A different venv is tracked independently.
+        let other_venv = PathBuf::from("/tmp/other/.venv");
+        assert!(state.should_notify_backend_failure(&other_venv, t0 + Duration::from_secs(10)));
+    }
+
+    #[test]
+    fn should_notify_backend_failure_renotifies_after_ttl_expires() {
+        let mut state = test_state();
+        let venv = PathBuf::from("/tmp/project/.venv");
+        let t0 = Instant::now();
+
+        assert!(state.should_notify_backend_failure(&venv, t0));
+
+        // Just past the TTL: a new failure should notify again.
+        let after_ttl = t0 + NOTIFICATION_DEDUP_TTL + Duration::from_millis(1);
+        assert!(state.should_notify_backend_failure(&venv, after_ttl));
     }
 }

--- a/tests/backend_error_dedup_test.rs
+++ b/tests/backend_error_dedup_test.rs
@@ -1,0 +1,98 @@
+mod support;
+
+use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
+
+/// E2E: repeated backend-creation failures for the same venv must not spam
+/// the client with `window/showMessage` notifications (issue #26).
+///
+/// `pkg/.venv` is broken from the start (fake `pyright-langserver` exits
+/// immediately), so every `didOpen` under it hits the pool-miss path in
+/// `handle_did_open` and fails to spawn a backend. Opening 5 files in quick
+/// succession must produce exactly one client-visible error notification;
+/// the rest are suppressed by the per-venv TTL dedup in
+/// `notify_backend_error`, though each failure is still logged server-side.
+#[tokio::test]
+async fn repeated_broken_venv_failures_notify_once() {
+    let config = WorkspaceConfig {
+        packages: vec![PackageConfig {
+            name: "pkg".to_string(),
+            scenario: serde_json::json!({ "on_startup": [], "steps": [] }),
+            has_venv: false,
+        }],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    let pkg_dir = root.join("pkg");
+    support::write_broken_venv_fixture(&pkg_dir);
+
+    // Start the proxy from the workspace root (no `.venv` there), so no
+    // fallback backend is pre-spawned; the `pkg` backend spawns lazily on
+    // didOpen and fails every time.
+    let mut proxy = ProxyUnderTest::spawn(temp_dir, root.clone(), &root);
+
+    let root_uri = support::path_to_uri(&root);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    // Open 5 files under the same broken venv in quick succession.
+    for name in ["a", "b", "c", "d", "e"] {
+        let file = pkg_dir.join(format!("{name}.py"));
+        std::fs::write(&file, format!("{name} = 1\n")).unwrap();
+        let file_uri = support::path_to_uri(&file);
+        proxy.did_open(&file_uri, &format!("{name} = 1\n")).await;
+    }
+
+    // Exactly one error notification should surface for all 5 failures.
+    let notification = proxy
+        .wait_for_notification("window/showMessage", 5000)
+        .await;
+    let params = notification
+        .params
+        .expect("window/showMessage must have params");
+    assert_eq!(params["type"], 1, "expected Error severity");
+    let message = params["message"]
+        .as_str()
+        .expect("message field must be a string");
+    assert!(
+        message.contains("Failed to start LSP backend"),
+        "expected backend-failure message, got: {message}"
+    );
+
+    // A further request against the same broken venv must not trigger a
+    // second notification: it fails via the request/response path (a JSON-RPC
+    // error, not `notify_backend_error`), and the dedup window is still open.
+    let file_a_uri = support::path_to_uri(&pkg_dir.join("a.py"));
+    let (hover_resp, notifications) = proxy
+        .request_collecting(
+            "textDocument/hover",
+            serde_json::json!({
+                "textDocument": { "uri": &file_a_uri },
+                "position": { "line": 0, "character": 0 }
+            }),
+        )
+        .await;
+    let error = hover_resp
+        .error
+        .expect("hover against the broken venv must fail explicitly");
+    assert!(
+        error.message.contains("backend error"),
+        "expected a backend error response, got: {}",
+        error.message
+    );
+    assert!(
+        !notifications
+            .iter()
+            .any(|n| n.method.as_deref() == Some("window/showMessage")),
+        "no additional showMessage notification should be sent within the dedup TTL"
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}


### PR DESCRIPTION
## Summary

Since #100 contained the respawn-failure error path, every backend-creation failure for a venv now reliably reaches `notify_backend_error`. But repeated failures (e.g. a broken venv still failing after a bad `uv sync`) send a fresh `window/showMessage` error notification on every `didOpen`, spamming the client for as long as the venv stays broken.

## Changes

- `src/state.rs`: adds `NOTIFICATION_DEDUP_TTL` (const 30s, deliberately not an env var — this window has no operator-facing behavior to tune, and env parsing is being tightened separately in #102), `ProxyState.venv_error_notified_at: HashMap<PathBuf, Instant>`, and `should_notify_backend_failure(&mut self, venv_path, now)`. The timestamp is recorded only when a notification is actually sent, so the TTL window is anchored to the last *notified* failure rather than sliding forward on every failure — a continuously failing venv still gets re-notified once per TTL instead of never again.
- `src/proxy/diagnostics.rs`: `notify_backend_error` is the single choke point where the dedup check lives. `tracing::error!` runs unconditionally before the dedup gate, so every failure is still logged server-side; only the client-visible `window/showMessage` is suppressed.
- `src/proxy/pool_management.rs`: clears the dedup entry for a venv as soon as a backend spawn succeeds, so recovery is followed by immediate re-notification on the next failure.
- `tests/backend_error_dedup_test.rs`: new E2E `repeated_broken_venv_failures_notify_once` — 5 `didOpen`s in quick succession against a broken venv produce exactly one `window/showMessage`; a subsequent `hover` still gets its own explicit JSON-RPC error response (the request/response path is intentionally not deduped — it's a 1:1 protocol contract, not a spammable notification) without triggering an additional notification.

Two unit tests in `src/state.rs` cover `should_notify_backend_failure` directly via injected `Instant` values (no real sleeps): suppression within the TTL, re-notification after it expires, and independent tracking per venv.

## Tests

- `should_notify_backend_failure_dedupes_within_ttl` / `should_notify_backend_failure_renotifies_after_ttl_expires` (unit, `src/state.rs`)
- `repeated_broken_venv_failures_notify_once` (E2E, `tests/backend_error_dedup_test.rs`) — covers all three acceptance criteria from #26: at most one notification within 30s, re-notification after the TTL expires, and every failure still logged server-side.

`make all` (fmt + clippy `-D warnings` + full suite) passes. Verified independently in both the implementation and review passes.

Closes #26