### PR TITLE
chore: bump version to 0.2.16

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "typemux-cc",
       "source": "./",
       "description": "Python type-checker LSP multiplexer for Claude Code (pyright, ty, pyrefly)",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "homepage": "https://github.com/K-dash/typemux-cc",
       "repository": "https://github.com/K-dash/typemux-cc",
       "strict": false

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typemux-cc",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "Python type-checker LSP multiplexer for Claude Code (pyright, ty, pyrefly)",
   "author": {
     "name": "K-dash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "typemux-cc"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typemux-cc"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2021"
 rust-version = "1.75"
 


### PR DESCRIPTION
## Summary
Version bump for the 0.2.16 release: Cargo.toml, Cargo.lock, plugin.json, and marketplace.json all move from 0.2.15 to 0.2.16.

## Included since v0.2.15
- #100 — contain backend respawn failures in venv staleness check (#92)
- #110 — fail startup on invalid timeout/interval env vars (#102)
- #111 — bound warmup queue to prevent unbounded memory growth (#17)
- #112 — dedupe backend-error showMessage notifications per venv (#26)
- #99 — remove unused wrapper script (#98)
- #101 — docs reorganization, #107 — agent workflow hardening, #108 — atomic release workflow, #109 — CI deps

After merge, tag v0.2.16 will be pushed separately to trigger the release pipeline (first release on the atomic release.yml from #108; also verifies the #89 release-notes dedup fix end-to-end).