### PR TITLE
fix: canonicalize paths at venv resolution boundaries

### DIFF
--- a/src/venv.rs
+++ b/src/venv.rs
@@ -51,6 +51,10 @@ pub async fn get_git_toplevel(working_dir: &Path) -> Result<Option<PathBuf>, Ven
     if output.status.success() {
         let path_str = String::from_utf8_lossy(&output.stdout);
         let path = PathBuf::from(path_str.trim());
+        // `git rev-parse --show-toplevel` already resolves symlinks, but
+        // canonicalize defensively so this is guaranteed to match the form
+        // `find_venv` canonicalizes the file path to.
+        let path = path.canonicalize().unwrap_or(path);
         tracing::info!(toplevel = %path.display(), "Git toplevel found");
         Ok(Some(path))
     } else {
@@ -99,8 +103,14 @@ pub fn find_venv(file_path: &Path, git_toplevel: Option<&Path>) -> Option<PathBu
         "Starting .venv search"
     );
 
-    // Start from file's parent directory
-    let mut current = file_path.parent();
+    // Canonicalize the starting directory so the upward walk and the
+    // `git_toplevel` boundary (already canonicalized in `get_git_toplevel`)
+    // agree on symlink resolution. Falls back to the raw path when the file
+    // (or its parent) does not exist yet, e.g. an unsaved buffer.
+    let start = file_path
+        .parent()
+        .map(|dir| dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf()));
+    let mut current = start.as_deref();
     let mut depth = 0;
 
     while let Some(dir) = current {
@@ -215,20 +225,85 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_venv() {
+        // Canonicalize to resolve symlinks (e.g., /var -> /private/var on
+        // macOS): find_venv now returns a canonical path, so the expected
+        // value must be canonical too.
         let temp = tempdir().unwrap();
-        let venv = temp.path().join(".venv");
+        let root = temp.path().canonicalize().unwrap();
+        let venv = root.join(".venv");
         fs::create_dir(&venv).await.unwrap();
         fs::write(venv.join("pyvenv.cfg"), "home = /usr/bin")
             .await
             .unwrap();
 
-        let subdir = temp.path().join("subdir");
+        let subdir = root.join("subdir");
         fs::create_dir(&subdir).await.unwrap();
         let file = subdir.join("test.py");
         fs::write(&file, "# test").await.unwrap();
 
         let result = find_venv(&file, None);
         assert_eq!(result, Some(venv));
+    }
+
+    #[tokio::test]
+    async fn test_find_venv_resolves_symlinked_project_dir() {
+        // The file path reaches the project through a symlink (mimicking a
+        // client URI with a logical path like macOS's /tmp -> /private/tmp),
+        // while `find_venv` walks physical directories. The returned venv
+        // path must still be canonical so it matches pool keys derived from
+        // the canonicalized git toplevel.
+        let temp = tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+
+        let real_project = root.join("real_project");
+        fs::create_dir(&real_project).await.unwrap();
+        let venv = real_project.join(".venv");
+        fs::create_dir(&venv).await.unwrap();
+        fs::write(venv.join("pyvenv.cfg"), "home = /usr/bin")
+            .await
+            .unwrap();
+
+        let symlink_project = root.join("symlinked_project");
+        std::os::unix::fs::symlink(&real_project, &symlink_project).unwrap();
+
+        let file = symlink_project.join("test.py");
+        fs::write(real_project.join("test.py"), "# test")
+            .await
+            .unwrap();
+
+        let result = find_venv(&file, None);
+        assert_eq!(result, Some(venv));
+    }
+
+    #[tokio::test]
+    async fn test_find_venv_respects_boundary_under_symlink() {
+        // Boundary check must still hold once both sides are canonicalized:
+        // a venv that lives above the (canonicalized) git toplevel must not
+        // be adopted, even when the file is reached through a symlink.
+        let temp = tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+
+        // Outer .venv, above the toplevel — must never be picked up.
+        let outer_venv = root.join(".venv");
+        fs::create_dir(&outer_venv).await.unwrap();
+        fs::write(outer_venv.join("pyvenv.cfg"), "home = /usr/bin")
+            .await
+            .unwrap();
+
+        let real_repo = root.join("real_repo");
+        fs::create_dir(&real_repo).await.unwrap();
+
+        let symlink_repo = root.join("symlinked_repo");
+        std::os::unix::fs::symlink(&real_repo, &symlink_repo).unwrap();
+
+        let file = symlink_repo.join("test.py");
+        fs::write(real_repo.join("test.py"), "# test")
+            .await
+            .unwrap();
+
+        // Toplevel is the (canonical) real repo dir — no .venv inside it.
+        let result = find_venv(&file, Some(&real_repo));
+        assert_eq!(result, None);
     }
 
     #[tokio::test]

--- a/tests/symlink_venv_test.rs
+++ b/tests/symlink_venv_test.rs
@@ -1,0 +1,167 @@
+mod support;
+
+use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
+
+/// Regression test for #95: `find_venv` must resolve `.venv` when the
+/// client's file URI reaches the project through a symlink that disagrees
+/// with the (already-canonicalized) git toplevel — the macOS `/tmp` ->
+/// `/private/tmp` case is the concrete example, reproduced here with an
+/// explicit symlink so it also exercises on Linux CI.
+///
+/// Also covers pool-key uniqueness: the same physical venv is reached via
+/// two textually different URIs (symlinked and physical), and a spawn
+/// counter embedded in the fake `pyright-langserver` script asserts only
+/// one backend process is ever spawned for it.
+#[tokio::test]
+async fn symlinked_project_path_resolves_venv_and_dedupes_pool_key() {
+    let scenario = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{
+                    "type": "respond",
+                    "body": { "capabilities": { "hoverProvider": true } }
+                }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{
+                    "type": "respond",
+                    "body": { "contents": { "kind": "plaintext", "value": "via symlink" } }
+                }]
+            },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{
+                    "type": "respond",
+                    "body": { "contents": { "kind": "plaintext", "value": "via physical" } }
+                }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![PackageConfig {
+            name: "pkg-a".to_string(),
+            scenario,
+            has_venv: true,
+        }],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    let pkg_dir = root.join("pkg-a");
+
+    // Instrument the fake `pyright-langserver` to record every spawn, so we
+    // can assert the pool never spawns a second backend for the logical vs.
+    // physical alias of the same venv.
+    let spawn_marker = root.join("spawn-marker.txt");
+    instrument_venv_spawn_marker(&pkg_dir, &spawn_marker);
+
+    // Symlink to the workspace root — the project reached through it has a
+    // different textual path from the (canonical) git toplevel, mirroring a
+    // client URI built from a logical path like macOS's /tmp -> /private/tmp.
+    let symlink_root = temp_dir.path().join("workspace-symlink");
+    std::os::unix::fs::symlink(&root, &symlink_root).unwrap();
+
+    let file_physical = pkg_dir.join("main.py");
+    std::fs::write(&file_physical, "x = 1\n").unwrap();
+
+    let mut proxy = ProxyUnderTest::spawn_with_env(
+        temp_dir,
+        root.clone(),
+        &root,
+        &[("RUST_LOG", "typemux_cc=warn")],
+    );
+
+    let root_uri = support::path_to_uri(&root);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    // didOpen + hover via the symlinked (logical) path.
+    let file_symlink_uri = support::path_to_uri(&symlink_root.join("pkg-a/main.py"));
+    proxy.did_open(&file_symlink_uri, "x = 1\n").await;
+
+    let hover_via_symlink = proxy
+        .request(
+            "textDocument/hover",
+            serde_json::json!({
+                "textDocument": { "uri": file_symlink_uri },
+                "position": { "line": 0, "character": 0 }
+            }),
+        )
+        .await;
+    assert!(
+        hover_via_symlink.error.is_none(),
+        "hover through the symlinked path should resolve the venv and succeed, got error: {:?}",
+        hover_via_symlink.error
+    );
+
+    // didOpen + hover via the physical path (same underlying file, same venv).
+    let file_physical_uri = support::path_to_uri(&file_physical);
+    proxy.did_open(&file_physical_uri, "x = 1\n").await;
+
+    let hover_via_physical = proxy
+        .request(
+            "textDocument/hover",
+            serde_json::json!({
+                "textDocument": { "uri": file_physical_uri },
+                "position": { "line": 0, "character": 0 }
+            }),
+        )
+        .await;
+    assert!(
+        hover_via_physical.error.is_none(),
+        "hover through the physical path should reuse the same pooled backend, got error: {:?}",
+        hover_via_physical.error
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+
+    // Both requests were served by the mock backend's single sequential step
+    // list (one didOpen+hover pair per alias) — if a second backend had been
+    // spawned under a distinct (non-canonical) pool key, the scenario's
+    // strict step ordering above would have failed instead of the spawn
+    // count below.
+    let spawn_count = std::fs::read_to_string(&spawn_marker).map_or(0, |s| s.lines().count());
+    assert_eq!(
+        spawn_count, 1,
+        "expected exactly one backend spawn for the venv shared by the symlinked and physical aliases"
+    );
+}
+
+/// Rewrite `<pkg_dir>/.venv/bin/pyright-langserver` (already created by
+/// `support::write_venv_fixture`) to append a line to `marker` on every
+/// invocation before delegating to `mock-lsp-backend`, so the test can
+/// count how many backend processes were actually spawned for the venv.
+fn instrument_venv_spawn_marker(pkg_dir: &std::path::Path, marker: &std::path::Path) {
+    let mock_backend_bin = env!("CARGO_BIN_EXE_mock-lsp-backend");
+    let script_path = pkg_dir.join(".venv/bin/pyright-langserver");
+    let script = format!(
+        "#!/bin/sh\necho spawned >> \"{}\"\nexport MOCK_LSP_SCENARIO_FILE=\"$VIRTUAL_ENV/scenario.json\"\nexec \"{}\" \"$@\"\n",
+        marker.display(),
+        mock_backend_bin
+    );
+    std::fs::write(&script_path, script).unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

`find_venv` walks up from a file's parent directory and stops at the git toplevel using `starts_with`. The file path comes from the client's URI (logical, may go through a symlink — e.g. macOS's `/tmp` -> `/private/tmp`) while the toplevel comes from `git rev-parse --show-toplevel` (physical). When the two disagreed, the boundary check failed on the very first iteration and strict mode reported `.venv not found` even though the venv existed right there. The inverse mismatch was also possible: the walk could escape the repo upward and adopt the wrong `.venv`.

## Changes

- `src/venv.rs`: `get_git_toplevel` now canonicalizes the toplevel path once, at the point it's captured. `find_venv` canonicalizes the file's parent directory once, at the start of the walk (falling back to the raw path if it doesn't exist yet, e.g. an unsaved buffer). Both sides of the `starts_with` boundary check now agree on symlink resolution, and the venv path `find_venv` returns is canonical end to end — so pool keys, `doc.venv`, and diagnostics filtering all see one consistent form instead of mixing logical and physical paths.
- Existing `test_find_venv` updated to expect a canonical path.

## Tests

- `test_find_venv_resolves_symlinked_project_dir` (unit, `src/venv.rs`): file reached through a symlinked project dir still resolves to the real `.venv`.
- `test_find_venv_respects_boundary_under_symlink` (unit, `src/venv.rs`): a `.venv` living above the (canonicalized) toplevel is still correctly rejected even when the file is reached through a symlink — confirms the fix doesn't loosen the boundary check.
- `symlinked_project_path_resolves_venv_and_dedupes_pool_key` (E2E, `tests/symlink_venv_test.rs`): opens the same file through both a symlinked and a physical URI and uses a spawn counter wired into the mock backend to assert exactly one backend process is spawned — proving the two aliases resolve to the same pool key. Verified to fail against the pre-fix source with the exact `.venv not found (strict mode)` error from the issue.

`make all` (fmt + clippy `-D warnings` + full suite) passes.

## Follow-up (out of scope here)

The document-restoration fallback in `src/proxy/initialization.rs` (`file_path.starts_with(venv_parent)`, used for documents with no recorded venv) still compares a raw client-URI path against the now-canonical venv parent. That's a pre-existing heuristic gap, not something this fix touches, and it overlaps with the #94 work in flight — left as a separate follow-up.

Closes #95
