### PR TITLE
fix: route URI-bearing client notifications to their owning backend

### DIFF
--- a/src/proxy/client_dispatch.rs
+++ b/src/proxy/client_dispatch.rs
@@ -444,11 +444,30 @@ impl super::LspProxy {
 
     /// Handle a generic client notification (not handled by specific handlers above).
     ///
-    /// Forwards to all backends in the pool.
+    /// If the notification carries `textDocument.uri`, it is routed to that
+    /// document's owning backend only (resolved via the same cache lookup as
+    /// `textDocument/didChange`). If no owning backend can be determined, the
+    /// notification is dropped rather than broadcast, to avoid delivering
+    /// document-scoped notifications to backends that never opened the
+    /// document. Notifications without a `textDocument.uri` (e.g.
+    /// `workspace/didChangeConfiguration`) are still broadcast to all
+    /// backends in the pool.
     pub(crate) async fn dispatch_client_notification(
         &mut self,
         msg: &RpcMessage,
     ) -> Result<(), ProxyError> {
+        if let Some(url) = Self::extract_text_document_uri(msg) {
+            let Some(venv_path) = self.venv_for_uri(&url) else {
+                tracing::warn!(
+                    method = ?msg.method_name(),
+                    uri = %url,
+                    "Dropping URI-bearing notification: no owning backend found"
+                );
+                return Ok(());
+            };
+            return self.forward_to_backend(&venv_path, msg).await;
+        }
+
         let venvs: Vec<PathBuf> = self.state.pool.backends_keys();
         for venv in &venvs {
             if let Some(inst) = self.state.pool.get_mut(venv) {

--- a/tests/notification_routing_test.rs
+++ b/tests/notification_routing_test.rs
@@ -1,0 +1,363 @@
+mod support;
+
+use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
+
+/// `RUST_LOG` is pinned so a developer's `~/.config/typemux-cc/config` (which
+/// may set `RUST_LOG=typemux_cc=trace`) can't slow down message processing
+/// enough to make the bounded `drain_notifications` windows below flaky.
+const ENV: &[(&str, &str)] = &[("RUST_LOG", "typemux_cc=warn")];
+
+/// E2E: `textDocument/didSave` for a proj-a document must reach only
+/// proj-a's backend.
+///
+/// proj-b's mock backend has no scripted step for a notification after its
+/// `didOpen` — if `didSave` leaks to it (the pre-fix broadcast bug), it
+/// treats the notification as an unexpected message and exits, which the
+/// proxy's crash-cleanup path surfaces as an unprompted, empty
+/// `textDocument/publishDiagnostics` for proj-b's document. Since a
+/// `didSave` notification carries no request id, that crash has no pending
+/// request to cancel — so absence of that spurious notification is the
+/// only reliable signal, and it is checked in a bounded window before
+/// issuing any further request (a later request would auto-respawn the
+/// crashed backend and mask the crash).
+#[tokio::test]
+// `file_a`/`file_b` (and their `_uri` variants) are deliberately parallel names
+// for the two test fixtures this scenario exercises.
+#[allow(clippy::similar_names)]
+async fn did_save_routes_only_to_owning_backend() {
+    let scenario_a = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            { "expect": { "method": "textDocument/didSave" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover from backend-a after save" } } }]
+            }
+        ]
+    });
+
+    // No step beyond didOpen: any further message (e.g. a leaked didSave)
+    // falls into the mock's drain loop, which treats it as unexpected.
+    let scenario_b = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![
+            PackageConfig {
+                name: "proj-a".to_string(),
+                scenario: scenario_a,
+                has_venv: true,
+            },
+            PackageConfig {
+                name: "proj-b".to_string(),
+                scenario: scenario_b,
+                has_venv: true,
+            },
+        ],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    let mut proxy = ProxyUnderTest::spawn_with_env(temp_dir, root.clone(), &root, ENV);
+
+    let root_uri = support::path_to_uri(&root);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    // didOpen for proj-a and proj-b → spawns both backends.
+    let file_a = root.join("proj-a/main.py");
+    std::fs::write(&file_a, "a = 1\n").unwrap();
+    let file_a_uri = support::path_to_uri(&file_a);
+    proxy.did_open(&file_a_uri, "a = 1\n").await;
+
+    let file_b = root.join("proj-b/main.py");
+    std::fs::write(&file_b, "b = 2\n").unwrap();
+    let file_b_uri = support::path_to_uri(&file_b);
+    proxy.did_open(&file_b_uri, "b = 2\n").await;
+
+    // Save only proj-a's document.
+    proxy
+        .notify(
+            "textDocument/didSave",
+            serde_json::json!({ "textDocument": { "uri": &file_a_uri } }),
+        )
+        .await;
+
+    // Bounded window for the crash-cleanup side effect to surface before it
+    // can be masked by a later request auto-respawning proj-b's backend.
+    let leaked = proxy.drain_notifications(500).await;
+    assert!(
+        leaked
+            .iter()
+            .all(|m| m.method.as_deref() != Some("textDocument/publishDiagnostics")),
+        "unexpected publishDiagnostics after didSave(proj-a) — proj-b's backend likely \
+         crashed from a spuriously delivered notification: {leaked:?}"
+    );
+
+    // proj-a must have consumed the didSave in order: hover only succeeds if
+    // the scenario's didOpen -> didSave -> hover sequence matched exactly.
+    let hover_a = proxy
+        .request(
+            "textDocument/hover",
+            serde_json::json!({
+                "textDocument": { "uri": &file_a_uri },
+                "position": { "line": 0, "character": 0 }
+            }),
+        )
+        .await;
+    assert!(
+        hover_a.error.is_none(),
+        "hover on proj-a should succeed after didSave, got error: {:?}",
+        hover_a.error
+    );
+    assert_eq!(
+        hover_a.result.as_ref().unwrap()["contents"]["value"],
+        "hover from backend-a after save"
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}
+
+/// E2E: a notification without `textDocument.uri` (e.g.
+/// `workspace/didChangeConfiguration`) still reaches every pooled backend.
+#[tokio::test]
+// `file_a`/`file_b` (and their `_uri` variants) are deliberately parallel names
+// for the two test fixtures this scenario exercises.
+#[allow(clippy::similar_names)]
+async fn non_uri_notification_still_broadcasts() {
+    let scenario_a = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            { "expect": { "method": "workspace/didChangeConfiguration" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover from backend-a after config" } } }]
+            }
+        ]
+    });
+
+    let scenario_b = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            { "expect": { "method": "workspace/didChangeConfiguration" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover from backend-b after config" } } }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![
+            PackageConfig {
+                name: "proj-a".to_string(),
+                scenario: scenario_a,
+                has_venv: true,
+            },
+            PackageConfig {
+                name: "proj-b".to_string(),
+                scenario: scenario_b,
+                has_venv: true,
+            },
+        ],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    let mut proxy = ProxyUnderTest::spawn_with_env(temp_dir, root.clone(), &root, ENV);
+
+    let root_uri = support::path_to_uri(&root);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file_a = root.join("proj-a/main.py");
+    std::fs::write(&file_a, "a = 1\n").unwrap();
+    let file_a_uri = support::path_to_uri(&file_a);
+    proxy.did_open(&file_a_uri, "a = 1\n").await;
+
+    let file_b = root.join("proj-b/main.py");
+    std::fs::write(&file_b, "b = 2\n").unwrap();
+    let file_b_uri = support::path_to_uri(&file_b);
+    proxy.did_open(&file_b_uri, "b = 2\n").await;
+
+    // No `textDocument` field: must broadcast to every pooled backend.
+    proxy
+        .notify(
+            "workspace/didChangeConfiguration",
+            serde_json::json!({ "settings": {} }),
+        )
+        .await;
+
+    let hover_a = proxy
+        .request(
+            "textDocument/hover",
+            serde_json::json!({
+                "textDocument": { "uri": &file_a_uri },
+                "position": { "line": 0, "character": 0 }
+            }),
+        )
+        .await;
+    assert!(
+        hover_a.error.is_none(),
+        "hover on proj-a should succeed after broadcast, got error: {:?}",
+        hover_a.error
+    );
+    assert_eq!(
+        hover_a.result.as_ref().unwrap()["contents"]["value"],
+        "hover from backend-a after config"
+    );
+
+    let hover_b = proxy
+        .request(
+            "textDocument/hover",
+            serde_json::json!({
+                "textDocument": { "uri": &file_b_uri },
+                "position": { "line": 0, "character": 0 }
+            }),
+        )
+        .await;
+    assert!(
+        hover_b.error.is_none(),
+        "hover on proj-b should succeed after broadcast, got error: {:?}",
+        hover_b.error
+    );
+    assert_eq!(
+        hover_b.result.as_ref().unwrap()["contents"]["value"],
+        "hover from backend-b after config"
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}
+
+/// E2E: `textDocument/didSave` for a document that was never opened is
+/// dropped without crashing the proxy or the (only) pooled backend.
+#[tokio::test]
+async fn did_save_for_unopened_document_is_dropped() {
+    let scenario = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover from pkg" } } }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![PackageConfig {
+            name: "pkg".to_string(),
+            scenario,
+            has_venv: true,
+        }],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    let mut proxy = ProxyUnderTest::spawn_with_env(temp_dir, root.clone(), &root, ENV);
+
+    let root_uri = support::path_to_uri(&root);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file = root.join("pkg/main.py");
+    std::fs::write(&file, "x = 1\n").unwrap();
+    let file_uri = support::path_to_uri(&file);
+    proxy.did_open(&file_uri, "x = 1\n").await;
+
+    // A URI that was never opened: no entry in the open-documents cache, so
+    // no owning backend can be resolved.
+    let never_opened_uri = support::path_to_uri(&root.join("pkg/never_opened.py"));
+    proxy
+        .notify(
+            "textDocument/didSave",
+            serde_json::json!({ "textDocument": { "uri": &never_opened_uri } }),
+        )
+        .await;
+
+    // Bounded window for a crash-cleanup side effect to surface before a
+    // later request could auto-respawn the backend and mask a crash.
+    let leaked = proxy.drain_notifications(500).await;
+    assert!(
+        leaked
+            .iter()
+            .all(|m| m.method.as_deref() != Some("textDocument/publishDiagnostics")),
+        "unexpected publishDiagnostics after didSave for an unopened document — the \
+         notification was likely broadcast instead of dropped: {leaked:?}"
+    );
+
+    // The pooled backend must still be alive and unperturbed.
+    let hover = proxy
+        .request(
+            "textDocument/hover",
+            serde_json::json!({
+                "textDocument": { "uri": &file_uri },
+                "position": { "line": 0, "character": 0 }
+            }),
+        )
+        .await;
+    assert!(
+        hover.error.is_none(),
+        "hover should succeed after the dropped didSave, got error: {:?}",
+        hover.error
+    );
+    assert_eq!(
+        hover.result.as_ref().unwrap()["contents"]["value"],
+        "hover from pkg"
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -235,6 +235,13 @@ impl ProxyUnderTest {
         self.write(&msg).await;
     }
 
+    /// Send an arbitrary fire-and-forget notification.
+    #[allow(dead_code)] // Used by some but not all integration test binaries.
+    pub async fn notify(&mut self, method: &str, params: Value) {
+        let msg = RpcMessage::notification(method, Some(params));
+        self.write(&msg).await;
+    }
+
     /// Send a request without waiting for its response. Returns the assigned
     /// id, for matching against a later `read_next`.
     #[allow(dead_code)] // Used by some but not all integration test binaries.
@@ -385,6 +392,27 @@ impl ProxyUnderTest {
                         "wait_for_notification: timed out after {timeout_ms}ms waiting for {method:?}\n--- stderr ---\n{stderr}"
                     );
                 }
+            }
+        }
+    }
+
+    /// Collect any messages that arrive within `wait_ms`, without panicking
+    /// if none arrive before the deadline. Used to give an async side effect
+    /// (e.g. backend-crash cleanup notifications) a bounded window to
+    /// surface, so a test can assert on its absence.
+    #[allow(dead_code)] // Used by some but not all integration test binaries.
+    pub async fn drain_notifications(&mut self, wait_ms: u64) -> Vec<RpcMessage> {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(wait_ms);
+        let mut collected = Vec::new();
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return collected;
+            }
+            match tokio::time::timeout(remaining, self.reader.read_message()).await {
+                Ok(Ok(msg)) => collected.push(msg),
+                Ok(Err(e)) => panic!("drain_notifications: framing error: {e}"),
+                Err(_) => return collected,
             }
         }
     }


### PR DESCRIPTION
## Summary

`dispatch_client_notification` broadcast every non-special-cased client notification to all pooled backends, so e.g. `textDocument/didSave` for a project-a document was also delivered to project-b's backend, even though project-b's backend never opened that document. Whether the receiving backend tolerates the stray notification is backend-dependent, and any future URI-bearing notification added to the proxy would inherit the same misrouting.

## Changes

- `src/proxy/client_dispatch.rs`: if the notification's params carry `textDocument.uri`, `dispatch_client_notification` now resolves the owning venv via the same open-documents cache lookup `textDocument/didChange` uses, and forwards only to that backend (reusing the existing `forward_to_backend` helper). If no owning backend can be determined (the document was never opened, or venv resolution failed at `didOpen`), the notification is dropped with a `tracing::warn!` — deliberately not broadcast, to avoid delivering document-scoped notifications to the wrong environment's backend. Notifications without `textDocument.uri` (e.g. `workspace/didChangeConfiguration`) keep the existing broadcast behavior. The declarative per-method routing table proposed in #103 is left as future work; this is the minimal fix for the misrouting itself.
- `tests/support/mod.rs`: two additive test-support helpers, `notify` (send an arbitrary fire-and-forget notification) and `drain_notifications` (collect messages within a bounded window without panicking if none arrive, used to assert on the *absence* of a side effect).

## Tests

New E2E file `tests/notification_routing_test.rs`:
- `did_save_routes_only_to_owning_backend` — two venv projects; proj-b's mock backend has no scripted step past `didOpen`, so a leaked `didSave` (the pre-fix broadcast bug) would crash it, which surfaces as an unprompted `textDocument/publishDiagnostics` from the proxy's crash-cleanup path. The test asserts that notification's absence in a bounded drain window, checked before any further request could auto-respawn the crashed backend and mask the crash.
- `non_uri_notification_still_broadcasts` — confirms notifications without `textDocument.uri` still reach every pooled backend.
- `did_save_for_unopened_document_is_dropped` — confirms a `didSave` for a URI with no open-documents cache entry is dropped without crashing the proxy or the pooled backend.

`make all` (fmt + clippy `-D warnings` + full suite) passes.

Closes #103