### PR TITLE
ci: pin GitHub Actions to commit SHAs and add zizmor security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,15 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+# Deny by default; each job below opts into the minimum it needs.
+permissions: {}
 
 jobs:
   ci:
     name: Makefile CI (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     timeout-minutes: 30
     strategy:
       # Let every platform leg finish even if another one fails, so a
@@ -40,13 +42,15 @@ jobs:
           - ubuntu-24.04-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       # Step timeout (25) is lower than the job timeout (30) on purpose: a
       # step timeout marks the step as failed, so the `if: failure()` upload
@@ -62,9 +66,29 @@ jobs:
       # step actually failed.
       - name: Upload CI diagnostics
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ci-diagnostics-${{ matrix.os }}
           path: ci-output.log
           if-no-files-found: warn
           retention-days: 3
+
+  zizmor:
+    name: zizmor (Actions security)
+    runs-on: ubuntu-latest # zizmor-action runs in a container; needs Docker
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          persona: regular
+          # Public repo, no Advanced Security tier needed: print findings to
+          # the log and fail the job on any finding instead of uploading SARIF.
+          advanced-security: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: read
+# Deny by default; each job below opts into the minimum it needs.
+permissions: {}
 
 jobs:
   validate:
@@ -23,16 +23,15 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Check version consistency & release tag
         run: ./scripts/check-versions.sh --release "$GITHUB_REF_NAME"
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Run quality gate
         run: make ci
@@ -59,10 +58,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -89,7 +90,7 @@ jobs:
       # the release itself is only ever created once, by `publish`, after
       # every matrix leg here has succeeded.
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.binary_name }}
           path: |
@@ -107,19 +108,35 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
           merge-multiple: true
 
-      # Create the release exactly once, with every asset attached and
-      # generated notes. Doing this in a single job also avoids the
-      # duplicated "What's Changed" section that appeared when notes were
-      # generated repeatedly across matrix legs.
+      # Fail loudly if a platform's binary or checksum is missing, instead of
+      # letting the glob below silently publish a partial release.
+      - name: Verify release assets
+        run: |
+          test "$(find artifacts -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 6
+          test -f artifacts/typemux-cc-macos-arm64
+          test -f artifacts/typemux-cc-macos-arm64.sha256
+          test -f artifacts/typemux-cc-linux-x86_64
+          test -f artifacts/typemux-cc-linux-x86_64.sha256
+          test -f artifacts/typemux-cc-linux-arm64
+          test -f artifacts/typemux-cc-linux-arm64.sha256
+
+      # `gh release create` is atomic by design: it creates a draft release,
+      # uploads every asset, and only publishes once every upload succeeds —
+      # so a failed upload never leaves a partial release public. This
+      # replaces the third-party softprops/action-gh-release action with the
+      # `gh` CLI already preinstalled on GitHub-hosted runners.
+      # `--verify-tag` stops `gh` from auto-creating a tag on the default
+      # branch if the pushed tag is somehow not found on the remote.
       - name: Create GitHub release with all assets
-        uses: softprops/action-gh-release@v3
-        with:
-          generate_release_notes: true
-          files: artifacts/*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" artifacts/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --generate-notes

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "timezone": "Asia/Tokyo",
   "schedule": [


### PR DESCRIPTION
## Summary

Hardens the GitHub Actions supply chain for `.github/workflows/*.yml`: every third-party action is now pinned to a full-length commit SHA, workflow/job permissions are audited to least-privilege, `persist-credentials: false` is set on checkouts that never push, and a required [zizmor](https://zizmor.sh/) job continuously enforces this going forward. No production code or runtime behavior changes.

## SHA resolution (primary sources)

Every SHA below was resolved via the GitHub REST API (`gh api repos/<owner>/<repo>/git/refs/tags/<tag>`, dereferencing annotated tags via `git/tags/<sha>`; branch tip via `git/refs/heads/<branch>`) — never copied from a blog post or other secondary source.

| Action | Ref (kept as comment) | Full SHA |
|---|---|---|
| `actions/checkout` | `v7` | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` |
| `actions/upload-artifact` | `v7` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `actions/download-artifact` | `v8` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |
| `Swatinem/rust-cache` | `v2` | `e18b497796c12c097a38f9edb9d0641fb99eee32` (annotated tag, dereferenced) |
| `dtolnay/rust-toolchain` | `stable` | `4be7066ada62dd38de10e7b70166bc74ed198c30` |
| `zizmorcore/zizmor-action` | `v0.5.7` | `192e21d79ab29983730a13d1382995c2307fbcaa` |

`softprops/action-gh-release` is **removed** (see below) rather than pinned.

### Why `dtolnay/rust-toolchain@stable` can be safely hash-pinned

This repo has no version tags for `dtolnay/rust-toolchain` other than `v1` — `stable`/`beta`/`nightly` are moving branches. Fetched the `stable` branch's `action.yml` directly (`raw.githubusercontent.com/dtolnay/rust-toolchain/stable/action.yml`): the action selects the toolchain from `inputs.toolchain`, which **defaults to the literal string `stable`** — it is not derived from the git ref name. Pinning the branch tip's commit therefore freezes the *action's code*, but at runtime it still runs `rustup toolchain install stable`, so it keeps installing whatever is currently the latest stable Rust. Hash-pinning does not change this workflow's behavior.

As a result, `rg 'uses: .*@(v|main|master|stable)' .github/workflows` returns **no matches** — no exceptions were needed.

## Permissions audit

- Workflow-level `permissions:` changed from `contents: read` to `permissions: {}` in both files; every job now declares its own minimum permissions explicitly (unchanged: `validate`/`build` = `contents: read`, `publish` = `contents: write`; `ci` = `contents: read`; new `zizmor` job = `contents: read`).
- `publish` (the only job with `contents: write`) only runs on `push: tags: v*` — it is never reachable from a `pull_request` event, so a fork PR can never obtain a write-scoped token from this workflow. `ci.yml`'s `pull_request` trigger never grants write to any job regardless.
- `persist-credentials: false` added to every checkout step (`ci`, `zizmor`, `validate`, `build`) — none of these jobs push, so there's no reason to leave a git credential on disk after checkout. `publish` has no checkout step (unchanged).

## zizmor (new required check in `ci.yml`)

- `zizmorcore/zizmor-action@192e21d7…` (pinned), `persona: regular` (high-signal, low-noise — matches what should gate CI), `advanced-security: false` (public repo, no SARIF/Code Scanning integration needed yet — findings print to the log and the step exits non-zero on any finding).
- Runs on `ubuntu-latest`: the action needs Docker, which GitHub-hosted macOS runners don't have by default.
- Verified locally: `uvx zizmor --persona=regular .github/workflows/` → **0 findings, exit 0** on the final workflow files.

### Findings surfaced during development (both resolved, not suppressed)

1. **`cache-poisoning`** on `release.yml`'s `Swatinem/rust-cache` step in `validate`: a tag-push/release-triggered workflow using a caching action is a cache-poisoning risk. Decision: **removed** the cache step from `validate` rather than suppress — releases are infrequent, a cold build there is cheap, and this keeps zizmor green with zero suppressions instead of maintaining a justification comment indefinitely. `ci.yml`'s cache step is unaffected (not a release-triggered workflow).
2. **`superfluous-actions`** on `release.yml`'s `softprops/action-gh-release` step: the same functionality is available via the `gh` CLI preinstalled on GitHub-hosted runners. Decision: **replaced** the action with `gh release create "$GITHUB_REF_NAME" artifacts/* --repo "$GITHUB_REPOSITORY" --verify-tag --generate-notes`. `gh release create` is atomic per its own docs (creates a draft, uploads every asset, publishes only once uploads succeed — a failed upload never leaves a partial release public), preserving the atomicity this workflow was built around (#108). `--verify-tag` prevents `gh` from auto-creating a tag on the default branch if the pushed tag isn't found on the remote. Added an explicit `Verify release assets` step (checks all 6 expected files by name) before publishing, since we no longer get the old action's implicit glob validation. Net effect: one fewer third-party action to pin/maintain.

No `zizmor.yml` config file and no `# zizmor: ignore[...]` suppressions were needed — both findings were fixed at the source.

## Renovate

Added `helpers:pinGitHubActionDigests` to `renovate.json`'s `extends`. Per Renovate's own docs (https://docs.renovatebot.com/modules/manager/github-actions/), a SHA-pinned action **with** a version/branch comment (which every pin above has) is already eligible for automatic digest-update PRs without this preset — but adding it makes the policy explicit and, importantly, means any *new* action someone adds to a workflow later without pinning it will be auto-converted by Renovate rather than silently left mutable.

## Recommended manual follow-up (not applied by this PR)

The repository's `sha_pinning_required` setting (`GET /repos/K-dash/typemux-cc/actions/permissions`) is currently `false` — this PR does not change it, per the request's scope. Recommend enabling it after merge so GitHub itself rejects any future unpinned `uses:` at the platform level, as defense-in-depth beneath zizmor and Renovate:

```
gh api --method PUT repos/K-dash/typemux-cc/actions/permissions -f sha_pinning_required=true
```

(or Settings → Actions → General → "Require actions to be pinned to a full-length commit SHA").

## Verification

- [x] Every pinned SHA is exactly 40 hex characters (machine-checked)
- [x] `rg 'uses: .*@(v|main|master|stable)' .github/workflows` → empty, no exceptions
- [x] `actionlint .github/workflows/*.yml` — exit 0
- [x] `uvx zizmor --persona=regular .github/workflows/` — 0 findings, exit 0
- [x] YAML syntax (`ruby -ryaml`) and `renovate.json` JSON syntax — OK
- [x] `make ci` — green
- [x] `git diff --check` — clean

## Scope

`.github/workflows/ci.yml`, `.github/workflows/release.yml`, `renovate.json`. No production code or test harness changes. No merge, no repository settings changes performed (the `sha_pinning_required` recommendation above is documentation only).