### PR TITLE
ci: add cargo-deny and Dependency Review, fix RUSTSEC-2026-0009

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,3 +109,30 @@ jobs:
       # No separate Rust toolchain setup: the action's container bundles one.
       - name: Run cargo-deny
         uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+
+  msrv:
+    name: MSRV (Rust 1.88)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      # `master`, not `stable`: passing an explicit `toolchain` input
+      # requires `master` per dtolnay/rust-toolchain's own docs (`stable`
+      # only carries the "always latest stable" default this input overrides).
+      - name: Setup Rust 1.88
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: "1.88"
+
+      # Guards the declared `rust-version` in Cargo.toml: without this, only
+      # the latest stable toolchain (via the `ci` job) is ever exercised, so
+      # a transitive dependency bump can silently raise the real minimum
+      # supported Rust version past what's declared.
+      - name: Check MSRV
+        run: cargo check --workspace --all-targets --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,20 @@ jobs:
           # Public repo, no Advanced Security tier needed: print findings to
           # the log and fail the job on any finding instead of uploading SARIF.
           advanced-security: false
+
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      # Checks advisories, licenses, bans, and sources against deny.toml.
+      # No separate Rust toolchain setup: the action's container bundles one.
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,33 @@
+name: Dependency Review
+
+# Diffs the dependencies a PR introduces against GitHub's advisory and
+# license data. Complements the `deny` job in ci.yml, which checks the whole
+# graph on every push/PR against deny.toml; this checks only what a PR
+# changes, using GitHub's own dependency-graph view.
+on:
+  pull_request:
+    paths-ignore:
+      - "*.md"
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: low
+          fail-on-scopes: runtime, development
+          # Same allow-list as deny.toml's [licenses], for consistency.
+          allow-licenses: MIT, Apache-2.0, Unicode-3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,12 +186,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "difflib"
@@ -486,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -851,30 +848,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "typemux-cc"
 version = "0.2.16"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.88"
 
 [lints.rust]
 warnings = "deny"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <div align="center">
   <a href="https://github.com/K-dash/typemux-cc/graphs/commit-activity"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/K-dash/typemux-cc"/></a>
   <a href="https://github.com/K-dash/typemux-cc/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/LICENSE-MIT-green"/></a>
-  <a href="https://www.rust-lang.org/"><img alt="Rust" src="https://img.shields.io/badge/rust-1.75+-orange.svg"/></a>
+  <a href="https://www.rust-lang.org/"><img alt="Rust" src="https://img.shields.io/badge/rust-1.88+-orange.svg"/></a>
   <a href="https://deepwiki.com/K-dash/typemux-cc"><img src="https://img.shields.io/badge/DeepWiki-K--dash%2Ftypemux--cc-blue.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==" alt="DeepWiki"></a>
 
 
@@ -166,7 +166,7 @@ On any failure it keeps the previously working binary and prints an explicit war
 
 ### Method B: Local Build (For Developers)
 
-> Requires Rust 1.75 or later. Running the full test suite (`cargo test` /
+> Requires Rust 1.88 or later. Running the full test suite (`cargo test` /
 > `make ci`) additionally requires [`jq`](https://jqlang.org/) — it's used by
 > `scripts/check-versions.sh` to validate the release version across
 > `Cargo.toml`, `Cargo.lock`, and the plugin manifests. Install it with

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,44 @@
+# cargo-deny configuration. Run locally with `cargo deny check`; enforced in
+# CI by the `deny` job in .github/workflows/ci.yml.
+#
+# https://embarkstudios.github.io/cargo-deny/
+
+[advisories]
+ignore = []
+
+[licenses]
+# Allow-list derived from the current dependency graph (`cargo metadata`),
+# not copied from a template. Every license expression in the graph resolves
+# via one of these three:
+# - MIT / Apache-2.0: the vast majority of crates.
+# - Unicode-3.0: required by the icu4x family (pulled in transitively via
+#   `url`'s IDNA support) and by unicode-ident, whose expression is
+#   `(MIT OR Apache-2.0) AND Unicode-3.0` — the AND means Unicode-3.0 must
+#   also be allowed, not just MIT/Apache-2.0.
+# Anything not covered by this list is denied by default; widening it is a
+# deliberate decision, not an implicit fallback.
+allow = ["MIT", "Apache-2.0", "Unicode-3.0"]
+confidence-threshold = 0.8
+
+[licenses.private]
+ignore = false
+
+[bans]
+# Only one duplicate exists in the current graph: bitflags 1.3.2 (only via
+# lsp-types -> fluent-uri) vs. 2.10.0 (used by everything else: tokio's
+# parking_lot chain, and dev-dependency tempfile's rustix). Denying
+# duplicates outright with a single, documented skip is more useful than
+# leaving this at "warn" forever: it catches any *new* duplicate immediately
+# instead of silently accumulating more.
+multiple-versions = "deny"
+wildcards = "deny"
+skip = [
+    { crate = "bitflags@1.3.2", reason = "the only consumer left on bitflags 1.x is lsp-types 0.97 (via fluent-uri); every other dependency in the graph already uses bitflags 2.x. Re-check when lsp-types updates its URI parser." },
+]
+
+[sources]
+# crates.io only. No git or alternate-registry dependencies exist today;
+# denying (not warning) means a new one must be added here deliberately.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

Adds continuous dependency-security checks so known-vulnerable crates, disallowed licenses, and unexpected dependency sources are caught in CI — not just at Renovate's next scheduled run. No production code changes (a security-driven `time` update and the consequent MSRV raise are included; see below — both are lockfile/manifest changes, not source changes).

- **`cargo-deny`** (new `deny` job in `ci.yml`): full dependency-graph check against a new `deny.toml`, on every push and PR.
- **GitHub Dependency Review** (new `.github/workflows/dependency-review.yml`): PR-diff check using GitHub's own advisory/license data, complementary to cargo-deny.
- **Fixed RUSTSEC-2026-0009**, which required raising the project's MSRV (see below — this was caught in review before merge).

## Investigation (against the real `Cargo.lock`, 131 packages)

- **Source**: every package resolves to `registry+https://github.com/rust-lang/crates.io-index`. No git dependencies, no alternate registries — zero exceptions needed for a strict `[sources]` policy.
- **Licenses**: `cargo metadata` shows every license expression in the graph reduces to three SPDX identifiers: `MIT`, `Apache-2.0`, `Unicode-3.0`. The last is required because `unicode-ident`'s expression is `(MIT OR Apache-2.0) AND Unicode-3.0` — an `AND` clause, so `Unicode-3.0` must be explicitly allowed too, not just MIT/Apache-2.0. It also covers the `icu4x` family pulled in transitively via `url`'s IDNA support. Zero unlicensed crates.
- **Duplicates**: exactly one — `bitflags` 1.3.2 (only reachable via `lsp-types` → `fluent-uri`) vs. 2.10.0 (used by everything else: `tokio`'s `parking_lot` chain, and dev-dependency `tempfile`'s `rustix`). With only one exception needed, `deny.toml` sets `bans.multiple-versions = "deny"` with a single documented `skip` entry, rather than leaving it at the default `"warn"` forever.
  - Verified this is actually enforced, not just configured: temporarily removing the skip makes `cargo deny check bans` fail with `error[duplicate]` (exit 2); restoring it passes.

## RUSTSEC-2026-0009 and the MSRV raise (1.75 → 1.88)

`cargo deny check` (before any `[advisories.ignore]` entries) reported `RUSTSEC-2026-0009` (stack-exhaustion DoS in RFC 2822 date parsing) in `time 0.3.44`, pulled in transitively by direct dependency `tracing-appender 0.2.5`.

Review caught an issue with the first fix attempt: naively bumping to the latest `time` (`cargo update -p time` → 0.3.53) raises the project's real minimum supported Rust version, because:

- `time` 0.3.53 and `time-macros` 0.2.31 both declare `rust-version = "1.88.0"` in their own `Cargo.toml` (verified directly from the downloaded crate sources in `~/.cargo/registry/src`, not just the advisory page).
- Checking the full version history via the crates.io API: **every** `time` release from 0.3.42 onward already requires 1.81+, and every release from 0.3.46 onward (which includes 0.3.47, the first release containing the fix) requires 1.88. There is no version `>= 0.3.44` that both fixes the advisory and supports Rust 1.75 — pinning to exactly 0.3.47 doesn't avoid the MSRV bump.
- This means the project's declared `rust-version = "1.75"` was **already silently unenforced before this PR**: even the previous `time 0.3.44` requires Rust 1.81. Nothing in CI ever built against the declared minimum, since every existing job uses `dtolnay/rust-toolchain@stable` (always the latest stable toolchain).

Decision (raise MSRV, don't suppress the advisory): typemux-cc ships prebuilt binaries as the primary install path (`install.sh`), so raising the source-build requirement only affects developers building from source, not end users. Keeping a narrow `# zizmor`-style `[advisories.ignore]` exception for RUSTSEC-2026-0009 was considered (the vulnerable code path — parsing user-controlled RFC 2822 dates — isn't reachable here; `tracing-appender` only uses `time` for local log-file naming), but raising the MSRV avoids carrying a permanent, easy-to-forget exception and keeps `cargo-deny` at zero exceptions from day one.

Changes:
- `Cargo.toml`: `rust-version = "1.75"` → `"1.88"`.
- `README.md`: badge and local-build note updated to match.
- New `msrv` job in `ci.yml`: installs Rust 1.88 explicitly (`dtolnay/rust-toolchain@master` with `toolchain: "1.88"` — per that action's own docs, an explicit `toolchain` input requires the `master` ref, not `stable`) and runs `cargo check --workspace --all-targets --locked`, so the declared MSRV is continuously verified going forward instead of silently drifting again.
- Verified locally: `rustup toolchain install 1.88 && cargo +1.88 check --workspace --all-targets --locked` — succeeds.

## `deny.toml` policy

```toml
[advisories]
ignore = []

[licenses]
allow = ["MIT", "Apache-2.0", "Unicode-3.0"]
confidence-threshold = 0.8

[bans]
multiple-versions = "deny"
wildcards = "deny"
skip = [{ crate = "bitflags@1.3.2", reason = "..." }]

[sources]
unknown-registry = "deny"
unknown-git = "deny"
allow-registry = ["https://github.com/rust-lang/crates.io-index"]
```

## Why a separate `dependency-review.yml` (not a job in `ci.yml`)

Dependency Review only makes sense on `pull_request` (it diffs base vs. head) — matching its own upstream convention avoids an `if: github.event_name == 'pull_request'` guard on an otherwise push-triggered job. `comment-summary-in-pr` is left at its default (`never`), so no `pull-requests: write` permission is needed; results are visible on the job log/summary page. Uses the same `MIT, Apache-2.0, Unicode-3.0` license allow-list as `deny.toml` for consistency, and `fail-on-scopes: runtime, development` (the action's own default is `runtime` only) so our dev-dependencies are covered too.

**Known, accepted gap**: per the action's own docs, if it can't detect a dependency's license, it reports but does not fail. This is fully covered by `cargo-deny`'s stricter default (an undetected/unlisted license is denied), which runs on the same PR via the `deny` job — the two checks are complementary, not redundant.

## Why no scheduled `cargo-audit`

`cargo-deny`'s `[advisories]` check already queries the same `rustsec/advisory-db` on every push and PR — strictly more frequent than a periodic cron job checking the same database against the same lockfile would be. Adding `cargo-audit` on a schedule would provide no additional coverage.

## Action SHAs (primary source: `gh api repos/<owner>/<repo>/git/refs/tags-or-heads/<ref>`, re-verified immediately before each commit)

| Action | Ref | Full SHA |
|---|---|---|
| `actions/checkout` | `v7` | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` (already pinned repo-wide from #121) |
| `EmbarkStudios/cargo-deny-action` | `v2.0.20` | `bb137d7af7e4fb67e5f82a49c4fce4fad40782fe` |
| `actions/dependency-review-action` | `v5.0.0` | `a1d282b36b6f3519aa1f3fc636f609c47dddb294` |
| `dtolnay/rust-toolchain` | `master` (MSRV job only) | `fa04a1451ff1842e2626ccb99004d0195b455a88` |

`cargo-deny-action@v2.0.20`'s own `Dockerfile` bakes in `deny_version="0.19.8"` — the exact version installed locally, so every `cargo deny check` result reported above will reproduce identically in CI.

## Renovate: no change needed (investigated, not modified)

Checked whether `renovate.json`'s `"schedule": ["every weekend"]` could delay a security fix. Per Renovate's own docs: *"When Renovate creates a vulnerabilityAlerts PR, it ignores settings like ... `schedule` ... vulnerability alerts 'skip the line'."* So the existing schedule does not delay real vulnerability-driven PRs — no `renovate.json` change was needed. The actual gap is that GitHub vulnerability alerts are disabled for this repo (see below): Renovate can't act on an alert that doesn't exist yet.

## Recommended manual follow-up (not applied by this PR)

Read-only checks via `gh api repos/K-dash/typemux-cc` (values as of this PR):

- **Enable Dependabot security updates / vulnerability alerts** — currently `dependabot_security_updates: disabled`, and the vulnerability-alerts endpoint returns 404 (disabled). This is what lets Renovate's `vulnerabilityAlerts` "skip the line" behavior have something to act on.
- **Enable CodeQL default setup** — no CodeQL workflow currently exists.
- **Add `cargo-deny`, `Dependency Review`, and `MSRV` to required status checks** — the `main` branch ruleset currently requires the 3 `Makefile CI` legs and `zizmor (Actions security)`; consider adding the new checks from this PR.

## Verification

- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok` (only a benign `no-license-field` note on our own unpublished `typemux-cc` crate, same rationale as the existing `cargo_common_metadata = "allow"` clippy lint)
- [x] Positive control: removing the `bitflags` skip makes `bans` fail (`error[duplicate]`, exit 2); confirms the policy is genuinely enforced
- [x] `cargo +1.88 check --workspace --all-targets --locked` — green (MSRV actually builds, not just declared)
- [x] `make ci` (default toolchain) — green
- [x] `uvx zizmor --persona=regular .github/workflows/` — 0 findings on all workflow files
- [x] `actionlint .github/workflows/*.yml` — exit 0
- [x] YAML syntax (`ruby -ryaml`) for both workflow files
- [x] `git diff --check` — clean
- [x] Every SHA is exactly 40 hex characters (machine-checked)

## Scope

`deny.toml` (new), `.github/workflows/dependency-review.yml` (new), `.github/workflows/ci.yml` (new `deny` and `msrv` jobs), `Cargo.lock` (`time` update only), `Cargo.toml` (`rust-version` bump), `README.md` (MSRV badge/note). No merge, no repository settings changes, no security alert dismissals.