### PR TITLE
test: harden E2E harness hermeticity and cover fan-out, warmup, cancelRequest

### DIFF
--- a/tests/cancel_request_test.rs
+++ b/tests/cancel_request_test.rs
@@ -1,0 +1,110 @@
+mod support;
+
+use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
+
+/// E2E: `$/cancelRequest` for a pending, already-forwarded request is
+/// relayed to the owning backend, and a subsequent request on the same
+/// backend still gets a normal response afterwards (proving
+/// `pending_requests` bookkeeping wasn't corrupted by the cancellation).
+///
+/// The mock backend DSL can only respond to the request that satisfied the
+/// *current* step's `expect` (`Action::Respond` always mirrors that
+/// message's id), so it has no way to fabricate a JSON-RPC error response
+/// tied to the *earlier* hover's id from within a later step. This test
+/// therefore proves the contract observable through the DSL: forwarding
+/// (the backend must see `$/cancelRequest` as the very next message after
+/// the cancelled hover, or the scripted step order breaks and the mock
+/// exits) and non-corruption (a fresh request on the same backend still
+/// succeeds normally afterwards). See the report for the full reasoning.
+#[tokio::test]
+async fn cancel_request_forwarded_and_backend_still_usable() {
+    let scenario = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            // First hover is deliberately left unanswered: it's the one
+            // that gets cancelled.
+            { "expect": { "method": "textDocument/hover" }, "actions": [] },
+            // If $/cancelRequest were not forwarded, the next message the
+            // backend actually sees is the second hover below instead of
+            // this notification, which mismatches this step and crashes
+            // the mock — a loud, detectable failure.
+            { "expect": { "method": "$/cancelRequest" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover after cancel" } } }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![PackageConfig {
+            name: "pkg".to_string(),
+            scenario,
+            has_venv: true,
+        }],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    let mut proxy = ProxyUnderTest::spawn(temp_dir, root.clone(), &root);
+
+    let root_uri = support::path_to_uri(&root);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file_a = root.join("pkg/a.py");
+    std::fs::write(&file_a, "a = 1\n").unwrap();
+    let file_a_uri = support::path_to_uri(&file_a);
+    proxy.did_open(&file_a_uri, "a = 1\n").await;
+
+    let hover_params = || {
+        serde_json::json!({
+            "textDocument": { "uri": &file_a_uri },
+            "position": { "line": 0, "character": 0 }
+        })
+    };
+
+    // First hover: forwarded to the backend and left pending on purpose.
+    let cancelled_id = proxy
+        .send_request("textDocument/hover", hover_params())
+        .await;
+
+    // Cancel it. The proxy has no pending fan-out or warmup queue entry for
+    // this id, so it takes the "forward $/cancelRequest to backends" path.
+    proxy
+        .notify("$/cancelRequest", serde_json::json!({ "id": cancelled_id }))
+        .await;
+
+    // A fresh request on the same backend must still work normally: this
+    // only succeeds if the mock progressed past its $/cancelRequest step,
+    // proving the cancellation was actually forwarded.
+    let hover2 = proxy.request("textDocument/hover", hover_params()).await;
+    assert!(
+        hover2.error.is_none(),
+        "hover after cancellation should not return an error, got: {:?}",
+        hover2.error
+    );
+    assert_eq!(
+        hover2.result.as_ref().unwrap()["contents"]["value"],
+        "hover after cancel"
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}

--- a/tests/fanout_test.rs
+++ b/tests/fanout_test.rs
@@ -1,0 +1,283 @@
+mod support;
+
+use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
+
+/// E2E: `workspace/symbol` with two pooled backends fans out to both and
+/// merges their result sets into a single response.
+#[tokio::test]
+async fn fanout_merges_results_from_two_backends() {
+    let scenario_a = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "workspaceSymbolProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "workspace/symbol" },
+                "actions": [{ "type": "respond", "body": [
+                    {
+                        "name": "FooA",
+                        "kind": 12,
+                        "location": {
+                            "uri": "file:///proj-a/main.py",
+                            "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 3 } }
+                        }
+                    }
+                ] }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+
+    let scenario_b = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "workspaceSymbolProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "workspace/symbol" },
+                "actions": [{ "type": "respond", "body": [
+                    {
+                        "name": "FooB",
+                        "kind": 12,
+                        "location": {
+                            "uri": "file:///proj-b/main.py",
+                            "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 3 } }
+                        }
+                    }
+                ] }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![
+            PackageConfig {
+                name: "proj-a".to_string(),
+                scenario: scenario_a,
+                has_venv: true,
+            },
+            PackageConfig {
+                name: "proj-b".to_string(),
+                scenario: scenario_b,
+                has_venv: true,
+            },
+        ],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    // Start proxy from workspace root (no fallback venv at root level), so
+    // each backend is spawned via the pool-miss path (one "initialized" each).
+    let mut proxy = ProxyUnderTest::spawn(temp_dir, root.clone(), &root);
+
+    let root_uri = support::path_to_uri(&root);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    // didOpen on each package spawns its backend.
+    let file_a = root.join("proj-a/main.py");
+    std::fs::write(&file_a, "a = 1\n").unwrap();
+    proxy
+        .did_open(&support::path_to_uri(&file_a), "a = 1\n")
+        .await;
+
+    let file_b = root.join("proj-b/main.py");
+    std::fs::write(&file_b, "b = 2\n").unwrap();
+    proxy
+        .did_open(&support::path_to_uri(&file_b), "b = 2\n")
+        .await;
+
+    // workspace/symbol has no document URI: with 2 pooled backends this
+    // fans out to both and merges their results.
+    let symbol_resp = proxy
+        .request("workspace/symbol", serde_json::json!({ "query": "Foo" }))
+        .await;
+    assert!(
+        symbol_resp.error.is_none(),
+        "workspace/symbol should not return an error, got: {:?}",
+        symbol_resp.error
+    );
+
+    let results = symbol_resp
+        .result
+        .as_ref()
+        .and_then(serde_json::Value::as_array)
+        .expect("workspace/symbol result should be an array");
+    let names: Vec<&str> = results
+        .iter()
+        .map(|item| item["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        results.len(),
+        2,
+        "expected merged results from both backends, got: {names:?}"
+    );
+    assert!(names.contains(&"FooA"), "missing FooA, got: {names:?}");
+    assert!(names.contains(&"FooB"), "missing FooB, got: {names:?}");
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}
+
+/// E2E: `workspace/symbol` fanned out to two backends, one of which never
+/// responds, returns the other backend's results (not an error, not a
+/// hang) once the fan-out timeout elapses.
+#[tokio::test]
+async fn fanout_returns_partial_results_on_backend_timeout() {
+    let scenario_a = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "workspaceSymbolProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "workspace/symbol" },
+                "actions": [{ "type": "respond", "body": [
+                    {
+                        "name": "FooA",
+                        "kind": 12,
+                        "location": {
+                            "uri": "file:///proj-a/main.py",
+                            "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 3 } }
+                        }
+                    }
+                ] }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+
+    // Backend B never responds to workspace/symbol: it just sits there.
+    // The proxy sends it a best-effort $/cancelRequest once the fan-out
+    // times out, so the scenario accounts for that before shutdown.
+    let scenario_b = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "workspaceSymbolProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            { "expect": { "method": "workspace/symbol" }, "actions": [] },
+            { "expect": { "method": "$/cancelRequest" }, "actions": [] },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![
+            PackageConfig {
+                name: "proj-a".to_string(),
+                scenario: scenario_a,
+                has_venv: true,
+            },
+            PackageConfig {
+                name: "proj-b".to_string(),
+                scenario: scenario_b,
+                has_venv: true,
+            },
+        ],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    // Short fan-out timeout so the test doesn't wait the 5s default.
+    let mut proxy = ProxyUnderTest::spawn_with_env(
+        temp_dir,
+        root.clone(),
+        &root,
+        &[("TYPEMUX_CC_FANOUT_TIMEOUT", "1")],
+    );
+
+    let root_uri = support::path_to_uri(&root);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file_a = root.join("proj-a/main.py");
+    std::fs::write(&file_a, "a = 1\n").unwrap();
+    proxy
+        .did_open(&support::path_to_uri(&file_a), "a = 1\n")
+        .await;
+
+    let file_b = root.join("proj-b/main.py");
+    std::fs::write(&file_b, "b = 2\n").unwrap();
+    proxy
+        .did_open(&support::path_to_uri(&file_b), "b = 2\n")
+        .await;
+
+    // Backend B never answers, so the response only arrives once the 1s
+    // fan-out timeout fires and the proxy returns backend A's partial
+    // results. The harness's 5s read timeout gives ample margin over that.
+    let (symbol_resp, notifications) = proxy
+        .request_collecting("workspace/symbol", serde_json::json!({ "query": "Foo" }))
+        .await;
+
+    assert!(
+        symbol_resp.error.is_none(),
+        "workspace/symbol should not return an error on partial timeout, got: {:?}",
+        symbol_resp.error
+    );
+    let results = symbol_resp
+        .result
+        .as_ref()
+        .and_then(serde_json::Value::as_array)
+        .expect("workspace/symbol result should be an array");
+    assert_eq!(
+        results.len(),
+        1,
+        "expected only backend A's result, got: {results:?}"
+    );
+    assert_eq!(results[0]["name"], "FooA");
+
+    let timeout_warning = notifications.iter().any(|n| {
+        n.method.as_deref() == Some("window/showMessage")
+            && n.params
+                .as_ref()
+                .and_then(|p| p["message"].as_str())
+                .is_some_and(|m| m.contains("fan-out timeout"))
+    });
+    assert!(
+        timeout_warning,
+        "expected a window/showMessage about the fan-out timeout, got: {notifications:?}"
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}

--- a/tests/harness_hermeticity_test.rs
+++ b/tests/harness_hermeticity_test.rs
@@ -1,0 +1,136 @@
+mod support;
+
+use std::time::{Duration, Instant};
+use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
+
+/// E2E: the harness redirects a spawned proxy's `HOME` (see #120), so
+/// `~/.config/typemux-cc/config` resolves under a harness-controlled
+/// directory rather than the developer's real one.
+///
+/// This is proven positively rather than by touching the real `$HOME`
+/// (which would risk clobbering a developer's actual config): a config file
+/// is planted at `<fake_home>/.config/typemux-cc/config` setting
+/// `TYPEMUX_CC_WARMUP_TIMEOUT=0` (disables warmup, so an index-dependent
+/// request is answered immediately instead of queued for up to the 2s
+/// default). `HOME` is passed as an explicit `spawn_with_env` entry, so this
+/// also doubles as the "explicit env wins over harness defaults" check for
+/// `HOME` specifically (the harness's own default is a *different*,
+/// empty per-spawn temp dir with no config file).
+///
+/// If `HOME` redirection were broken (e.g. the proxy fell back to
+/// inheriting the test process's own real `HOME`), this fake config would
+/// never be read: the proxy would use the hardcoded 2s default warmup
+/// timeout, and the definition request below would only be answered after
+/// that timeout's fail-open drain — comfortably tripping the 500ms budget
+/// asserted below.
+#[tokio::test]
+async fn config_at_redirected_home_takes_effect() {
+    let fake_home = tempfile::TempDir::new().expect("failed to create fake HOME dir");
+    let config_dir = fake_home.path().join(".config").join("typemux-cc");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(config_dir.join("config"), "TYPEMUX_CC_WARMUP_TIMEOUT=0\n").unwrap();
+
+    let scenario = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true, "definitionProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            // dispatch_initialized forwards a 2nd "initialized" to fallback backends
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover ok" } } }]
+            },
+            {
+                "expect": { "method": "textDocument/definition" },
+                "actions": [{ "type": "respond", "body": { "uri": "file:///a.py", "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 1 } } } }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![PackageConfig {
+            name: "pkg".to_string(),
+            scenario,
+            has_venv: true,
+        }],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    let pkg_dir = root.join("pkg");
+    let mut proxy = ProxyUnderTest::spawn_with_env(
+        temp_dir,
+        root.clone(),
+        &pkg_dir,
+        &[("HOME", fake_home.path().to_str().unwrap())],
+    );
+
+    let root_uri = support::path_to_uri(&pkg_dir);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file_a = pkg_dir.join("a.py");
+    std::fs::write(&file_a, "a = 1\n").unwrap();
+    let file_a_uri = support::path_to_uri(&file_a);
+    proxy.did_open(&file_a_uri, "a = 1\n").await;
+
+    // Synchronizing round trip: absorbs backend spawn latency outside the
+    // timed window below, and confirms the backend is fully up.
+    let hover = proxy
+        .request(
+            "textDocument/hover",
+            serde_json::json!({
+                "textDocument": { "uri": &file_a_uri },
+                "position": { "line": 0, "character": 0 }
+            }),
+        )
+        .await;
+    assert!(
+        hover.error.is_none(),
+        "hover should not return an error, got: {:?}",
+        hover.error
+    );
+
+    let start = Instant::now();
+    let def_resp = proxy
+        .request(
+            "textDocument/definition",
+            serde_json::json!({
+                "textDocument": { "uri": &file_a_uri },
+                "position": { "line": 0, "character": 0 }
+            }),
+        )
+        .await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        def_resp.error.is_none(),
+        "definition should not return an error, got: {:?}",
+        def_resp.error
+    );
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "definition took {elapsed:?}, expected well under 500ms: \
+         TYPEMUX_CC_WARMUP_TIMEOUT=0 at the redirected HOME's config should \
+         have disabled warmup queueing entirely (a broken HOME redirect \
+         would fall back to the crate's 2s default warmup timeout)"
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -13,6 +13,31 @@ use typemux_cc::message::{RpcId, RpcMessage};
 
 const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+// ── Hermeticity defaults ────────────────────────────────────────────
+//
+// Every spawned proxy is isolated from the developer's real environment
+// (see #120): `HOME` is redirected to a per-spawn temp dir so
+// `~/.config/typemux-cc/config` (src/config.rs:21-23) can't leak developer
+// settings into a test run, `PATH` is sanitized so a missing mock shim in
+// `.venv/bin` fails loudly instead of silently falling through to a real
+// `pyright-langserver`/`ty`/`pyrefly` install, and `RUST_LOG` gets a quiet
+// default instead of the crate's own `typemux_cc=debug` fallback. Applied
+// before `envs`, so an explicit entry in a test's `spawn_with_env` call
+// always overrides the default for that key.
+
+/// Minimal `PATH` for spawned proxies: enough to resolve `git` (venv
+/// boundary detection) and to exec the mock shim's `#!/bin/sh` shebang
+/// (resolved directly by the kernel, not via `PATH`). Excludes any
+/// developer-installed backend so a missing shim in `.venv/bin` is a loud,
+/// deterministic failure rather than a silent fallback to a real install.
+const HERMETIC_PATH: &str = "/usr/bin:/bin";
+
+/// Default `RUST_LOG` for spawned proxies. Quiets the crate's own
+/// `typemux_cc=debug` fallback (src/main.rs) and a developer's
+/// `~/.config/typemux-cc/config` possibly setting `RUST_LOG=trace`, either
+/// of which can push timing-sensitive E2E tests toward their read timeout.
+const HERMETIC_RUST_LOG: &str = "typemux_cc=warn";
+
 // ── Workspace configuration ────────────────────────────────────────
 
 /// Describes one package (sub-directory) inside the test workspace.
@@ -128,6 +153,10 @@ pub struct ProxyUnderTest {
     writer: LspFrameWriter<tokio::process::ChildStdin>,
     #[allow(dead_code)]
     temp_dir: TempDir,
+    // Kept alive for the proxy's lifetime: its path backs the spawned
+    // proxy's `HOME`, which `src/config.rs` reads at startup.
+    #[allow(dead_code)]
+    harness_home: TempDir,
     #[allow(dead_code)] // Read via `root()`, used by some but not all integration test binaries.
     root: PathBuf,
     next_id: i64,
@@ -149,6 +178,8 @@ impl ProxyUnderTest {
         envs: &[(&str, &str)],
     ) -> Self {
         let proxy_bin = env!("CARGO_BIN_EXE_typemux-cc");
+        let harness_home = TempDir::new().expect("failed to create harness HOME dir");
+
         let mut child = Command::new(proxy_bin)
             .current_dir(cwd)
             // Clear git env vars so the proxy's `git rev-parse` uses the test
@@ -157,6 +188,11 @@ impl ProxyUnderTest {
             .env_remove("GIT_DIR")
             .env_remove("GIT_WORK_TREE")
             .env_remove("GIT_INDEX_FILE")
+            // Hermeticity defaults (see the module-level comment above);
+            // `envs` is applied last so an explicit entry always wins.
+            .env("HOME", harness_home.path())
+            .env("PATH", HERMETIC_PATH)
+            .env("RUST_LOG", HERMETIC_RUST_LOG)
             .envs(envs.iter().copied())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -173,6 +209,7 @@ impl ProxyUnderTest {
             reader: LspFrameReader::new(stdout),
             writer: LspFrameWriter::new(stdin),
             temp_dir,
+            harness_home,
             root,
             next_id: 1,
         }

--- a/tests/warmup_flow_test.rs
+++ b/tests/warmup_flow_test.rs
@@ -1,0 +1,235 @@
+mod support;
+
+use std::collections::HashMap;
+use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
+use typemux_cc::message::{RpcId, RpcMessage};
+
+/// E2E: while a backend is warming, an index-dependent request
+/// (`textDocument/definition`) is queued rather than forwarded, and a
+/// non-index-dependent request (`textDocument/hover`) passes through
+/// immediately. Once the backend signals readiness via `$/progress` (kind
+/// "end"), the queued request is drained and answered.
+///
+/// Determinism: the proxy processes client messages strictly in the order
+/// they arrive on its stdin, so sending `definition` and then a second
+/// `hover` (with no intervening await) guarantees the proxy queues
+/// `definition` before it ever forwards the second `hover` to the backend
+/// — the backend's own `$/progress` end (attached to that second hover's
+/// reply) can therefore only be sent after `definition` is already queued.
+/// No sleeps are needed; see `tests/venv_staleness_test.rs` for the
+/// alternative (env-injected interval + sleep) pattern used when a real
+/// wall-clock race can't be avoided.
+#[tokio::test]
+async fn queued_definition_drains_after_progress_end_while_hover_passes_through() {
+    let scenario = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true, "definitionProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover before ready" } } }]
+            },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [
+                    { "type": "notify", "method": "$/progress", "params": { "token": "warmup", "value": { "kind": "end" } } },
+                    { "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover triggering ready" } } }
+                ]
+            },
+            {
+                "expect": { "method": "textDocument/definition" },
+                "actions": [{ "type": "respond", "body": { "uri": "file:///pkg/a.py", "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 1 } } } }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![PackageConfig {
+            name: "pkg".to_string(),
+            scenario,
+            has_venv: true,
+        }],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    // Start from workspace root (pool-miss spawn, single "initialized").
+    // Warmup timeout is generous: this test drives warmup completion via
+    // the $/progress signal, not the timeout (see the fail-open test below
+    // for that path), so the margin is just insurance against slow CI.
+    let mut proxy = ProxyUnderTest::spawn_with_env(
+        temp_dir,
+        root.clone(),
+        &root,
+        &[("TYPEMUX_CC_WARMUP_TIMEOUT", "10")],
+    );
+
+    let root_uri = support::path_to_uri(&root);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file_a = root.join("pkg/a.py");
+    std::fs::write(&file_a, "a = 1\n").unwrap();
+    let file_a_uri = support::path_to_uri(&file_a);
+    proxy.did_open(&file_a_uri, "a = 1\n").await;
+
+    let doc_params = || {
+        serde_json::json!({
+            "textDocument": { "uri": &file_a_uri },
+            "position": { "line": 0, "character": 0 }
+        })
+    };
+
+    // First hover: spawns the backend (still warming) and passes straight
+    // through, since hover is not index-dependent.
+    let hover1 = proxy.request("textDocument/hover", doc_params()).await;
+    assert!(
+        hover1.error.is_none(),
+        "first hover should not return an error, got: {:?}",
+        hover1.error
+    );
+    assert_eq!(
+        hover1.result.as_ref().unwrap()["contents"]["value"],
+        "hover before ready"
+    );
+
+    // definition is index-dependent and the backend is still warming: it
+    // must be queued, not forwarded. Sent before the second hover so the
+    // proxy queues it first (see the doc comment above on ordering).
+    let def_id = proxy
+        .send_request("textDocument/definition", doc_params())
+        .await;
+
+    // Second hover: still passes through immediately (not index-dependent).
+    // Its scripted reply carries the $/progress end that transitions the
+    // backend to Ready and drains the queued definition request.
+    let hover2_id = proxy.send_request("textDocument/hover", doc_params()).await;
+
+    let mut responses: HashMap<i64, RpcMessage> = HashMap::new();
+    while responses.len() < 2 {
+        let msg = proxy.read_next().await;
+        if let Some(RpcId::Number(id)) = &msg.id {
+            responses.insert(*id, msg);
+        }
+    }
+
+    let hover2 = &responses[&hover2_id];
+    assert!(
+        hover2.error.is_none(),
+        "second hover should not return an error, got: {:?}",
+        hover2.error
+    );
+    assert_eq!(
+        hover2.result.as_ref().unwrap()["contents"]["value"],
+        "hover triggering ready"
+    );
+
+    let def_resp = &responses[&def_id];
+    assert!(
+        def_resp.error.is_none(),
+        "queued definition should be drained and answered, got: {:?}",
+        def_resp.error
+    );
+    assert_eq!(def_resp.result.as_ref().unwrap()["uri"], "file:///pkg/a.py");
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}
+
+/// E2E: an index-dependent request queued during warmup is drained
+/// (forwarded, not left hanging or errored) once the warmup timeout
+/// elapses, even though the backend never sends a `$/progress` end event
+/// (fail-open).
+#[tokio::test]
+async fn warmup_fail_open_drains_queue_after_timeout() {
+    let scenario = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "definitionProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/definition" },
+                "actions": [{ "type": "respond", "body": { "uri": "file:///pkg/a.py", "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 1 } } } }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![PackageConfig {
+            name: "pkg".to_string(),
+            scenario,
+            has_venv: true,
+        }],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    // Short warmup timeout: the mock never sends $/progress end, so the
+    // queued request can only ever be drained via the timeout's fail-open
+    // path. The harness's 5s read timeout leaves ample margin over 1s.
+    let mut proxy = ProxyUnderTest::spawn_with_env(
+        temp_dir,
+        root.clone(),
+        &root,
+        &[("TYPEMUX_CC_WARMUP_TIMEOUT", "1")],
+    );
+
+    let root_uri = support::path_to_uri(&root);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file_a = root.join("pkg/a.py");
+    std::fs::write(&file_a, "a = 1\n").unwrap();
+    let file_a_uri = support::path_to_uri(&file_a);
+    proxy.did_open(&file_a_uri, "a = 1\n").await;
+
+    // Queued while warming; only answered once the 1s timeout fail-opens
+    // the backend to Ready and drains the queue.
+    let def_resp = proxy
+        .request(
+            "textDocument/definition",
+            serde_json::json!({
+                "textDocument": { "uri": &file_a_uri },
+                "position": { "line": 0, "character": 0 }
+            }),
+        )
+        .await;
+    assert!(
+        def_resp.error.is_none(),
+        "definition queued during warmup should be drained after fail-open, got: {:?}",
+        def_resp.error
+    );
+    assert_eq!(def_resp.result.as_ref().unwrap()["uri"], "file:///pkg/a.py");
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}


### PR DESCRIPTION
## Summary

Two related, test-only changes to the E2E suite: hermeticity fixes for the test harness itself, and coverage for previously-untested subsystems.

## Changes

**Hermeticity (#120):** every proxy the harness spawns now gets isolation defaults, applied before `spawn_with_env`'s explicit entries so per-test overrides still win:
- a per-spawn temp `HOME`, so the developer's real `~/.config/typemux-cc/config` can't leak into a test run
- a sanitized `PATH=/usr/bin:/bin`, so a missing mock shim in `.venv/bin` fails loudly instead of silently falling through to a real `pyright`/`ty`/`pyrefly` install on the developer's machine
- a quiet default `RUST_LOG`

New test `config_at_redirected_home_takes_effect` proves both properties behaviorally: the redirected config file is actually read, and an explicit env override still wins, using a warmup-timeout-0 config answering an index-dependent request in under 500ms versus the 2s default.

**Coverage (#97):** five new E2E tests over subsystems that had zero E2E coverage, using the existing mock-scenario DSL and env-injected timeouts (no bare sleeps):
- fan-out result merging across two backends
- fan-out partial results when one backend times out, plus the associated timeout warning notification
- warmup queueing of index-dependent requests (with pass-through of non-dependent ones) and drain on `$/progress` end
- warmup fail-open drain after `TYPEMUX_CC_WARMUP_TIMEOUT` expiry
- `$/cancelRequest` forwarding, including post-cancel backend usability (`pending_requests` cleanup)

Queue-full rejection is already covered by #111's test and isn't duplicated here.

TTL eviction is intentionally left out: the sweep tick is hardcoded to `Duration::from_secs(60)` in `src/proxy/mod.rs`, unlike the other timing-sensitive paths here which use env-injected intervals. Exercising it end-to-end needs that made configurable first, which is a production change out of scope for a test-only PR.

## Tests

Each new test was validated for detection power by temporarily breaking the exact code path it guards (e.g. emptying `FANOUT_METHODS`, forcing `should_queue = false`, disabling `warmup_expired`, no-oping the cancel forward), confirming the test fails, then reverting — every test's failure mode was proven real before being trusted.

`make all` (fmt + clippy `-D warnings` + full 21-binary suite) passes after each commit.

Closes #120
Refs #97