### PR TITLE
ci: read MSRV from Cargo.toml instead of hardcoding it in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
 
   msrv:
-    name: MSRV (declared in Cargo.toml)
+    name: MSRV
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
 
   msrv:
-    name: MSRV (Rust 1.88)
+    name: MSRV (declared in Cargo.toml)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -122,13 +122,26 @@ jobs:
         with:
           persist-credentials: false
 
+      # Cargo.toml's `rust-version` is the only source of truth for the MSRV.
+      # Reading it here (instead of hardcoding the version in this workflow)
+      # means there is nothing for a dependency bot to update independently
+      # of that declaration — see renovate.json's packageRules entry that
+      # disables updates to this job's toolchain dependency for the same
+      # reason.
+      - name: Read MSRV
+        id: msrv
+        run: |
+          msrv=$(sed -n 's/^rust-version = "\(.*\)"/\1/p' Cargo.toml)
+          test -n "$msrv"
+          echo "version=$msrv" >> "$GITHUB_OUTPUT"
+
       # `master`, not `stable`: passing an explicit `toolchain` input
       # requires `master` per dtolnay/rust-toolchain's own docs (`stable`
       # only carries the "always latest stable" default this input overrides).
-      - name: Setup Rust 1.88
+      - name: Setup declared MSRV
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
-          toolchain: "1.88"
+          toolchain: ${{ steps.msrv.outputs.version }}
 
       # Guards the declared `rust-version` in Cargo.toml: without this, only
       # the latest stable toolchain (via the `ci` job) is ever exercised, so

--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,13 @@
   "timezone": "Asia/Tokyo",
   "schedule": [
     "every weekend"
+  ],
+  "packageRules": [
+    {
+      "description": "MSRV is a compatibility policy declared in Cargo.toml's rust-version, read dynamically by the msrv job in ci.yml. Raising it is a deliberate, human decision, not a routine dependency bump.",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["rust"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes a real bug caught by review before merge: PR #123 (`chore(deps): update dependency rust to 1.97`, a Renovate PR) would have bumped the `msrv` job's `toolchain: "1.88"` input to `"1.97"` — while leaving `Cargo.toml`'s `rust-version = "1.88"` untouched and the job/step names still saying "1.88". Merging it would have made the `msrv` job silently test against the latest toolchain instead of the declared minimum, defeating its entire purpose while still showing a green check.

**PR #123 should be closed once this merges** — it's superseded by this fix and must not be merged as-is (confirmed via `gh pr diff 123`: it only changes the hardcoded `"1.88"` string, nothing else).

## Root cause

Renovate's `github-actions` manager tracks the `toolchain:` input passed to `dtolnay/rust-toolchain` as an independently-updatable dependency named `rust` — confirmed directly from PR #123's own title/branch (`renovate/rust-1.x`), not just from Renovate's docs. The `msrv` job (added in #122) hardcoded `toolchain: "1.88"` as a second, independent copy of the MSRV declared in `Cargo.toml`'s `rust-version` — two sources of truth that only stayed in sync as long as no automated tool touched either one.

## Fix

- `.github/workflows/ci.yml`: added a `Read MSRV` step that extracts the value directly from `Cargo.toml` (`sed -n 's/^rust-version = "\(.*\)"/\1/p' Cargo.toml`, with `test -n "$msrv"` to fail loudly if extraction ever comes up empty) and passes it to `dtolnay/rust-toolchain` via `${{ steps.msrv.outputs.version }}`. Job name changed from `MSRV (Rust 1.88)` to `MSRV (declared in Cargo.toml)` and the setup step from `Setup Rust 1.88` to `Setup declared MSRV` — neither embeds a version number anymore, so there's nothing left to go stale.
- `renovate.json`: added a `packageRules` entry disabling updates to the `rust` dependency (`matchManagers: ["github-actions"]`, `matchDepNames: ["rust"]`, `enabled: false`). MSRV is a compatibility policy — raising it should be a deliberate edit to `Cargo.toml` by a human, not something a dependency bot proposes.

With this, `Cargo.toml`'s `rust-version` is the only place the MSRV is written down; the CI job reads it rather than duplicating it.

## Verification

- [x] Simulated the extraction locally: `sed -n 's/^rust-version = "\(.*\)"/\1/p' Cargo.toml` → `1.88` (matches the current declaration exactly)
- [x] `cargo +1.88 check --workspace --all-targets --locked` (using the extracted value) — green
- [x] `make ci` (default toolchain) — green
- [x] `cargo deny check` — unaffected, still `advisories ok, bans ok, licenses ok, sources ok`
- [x] `uvx zizmor --persona=regular .github/workflows/` — 0 findings
- [x] `actionlint .github/workflows/*.yml` — exit 0
- [x] YAML syntax (`ruby -ryaml`) and `renovate.json` JSON syntax — OK
- [x] `git diff --check` — clean

## Scope

`.github/workflows/ci.yml` (msrv job only), `renovate.json` (new packageRule). No production code, no other CI jobs touched. No merge, no repository settings changes. PR #123 was not merged or closed by this session — recommend closing it manually once this PR merges.