### PR TITLE
docs: move Claude-specific guidance to CLAUDE.md and slim AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,8 @@ push does not authorize opening a pull request.
 
 # typemux-cc - Python Type-Checker LSP Multiplexer for Claude Code
 
-See @README.md for project overview.
-See @docs/ARCHITECTURE.md for architecture details.
+See README.md for project overview.
+See docs/ARCHITECTURE.md for architecture details.
 
 ## Build & Quality
 
@@ -76,23 +76,6 @@ Before committing, verify:
 - **No implicit fallbacks** — Never add silent fallback logic that masks errors. Let it fail loudly so unintended behavior is caught early. An explicit error is always better than a silent wrong result.
 - **No backward compatibility** — Do not preserve backward compatibility unless the user explicitly requests it. Breaking changes are the default; do not add compatibility shims, re-exports, or deprecation wrappers.
 
-### Rust Skills
-
-- When investigating or fixing Rust code, prefer rust-skills skills (m01–m15, domain-*, etc.)
-- For ownership/borrow/lifetime errors, load the corresponding m0x skill
-- For clippy errors or code review, load the relevant skill (e.g., coding-guidelines, m15-anti-pattern)
-
-### Plan-First Rule
-
-For changes touching **3 or more files** or introducing **new architectural patterns**:
-
-1. **Enter plan mode first** — use `EnterPlanMode` to explore the codebase and design the approach before writing any code.
-2. **Get the plan approved** — the user must approve before execution begins. The plan is the contract.
-3. **Include a verification strategy** — every plan must answer: "How will we verify this works?" (tests, manual checks, CI gates, etc.)
-4. **Stop if scope drifts** — if the implementation diverges from the approved plan, stop and re-plan rather than improvising.
-
-For small, well-scoped changes (single-file fixes, typo corrections, simple bug fixes), skip planning and execute directly.
-
 ## Code Style
 
 - Rust 2021 edition
@@ -111,10 +94,4 @@ For small, well-scoped changes (single-file fixes, typo corrections, simple bug 
 
 ## Project Structure
 
-See @docs/ARCHITECTURE.md for source code structure.
-
----
-
-## Known Mistakes & Lessons Learned
-
-<!-- Reverse-chronological. Format: ### YYYY-MM-DD: Description / What happened / Root cause / Rule -->
+See docs/ARCHITECTURE.md for source code structure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,21 @@
 # typemux-cc - Project Instructions
 
 All project rules are defined in @AGENTS.md. Read it before starting any work.
+
+## Rust Skills
+
+- Provided by the [rust-skills plugin](https://github.com/actionbook/rust-skills); skip this section if the plugin is not enabled
+- When investigating or fixing Rust code, prefer rust-skills skills (m01–m15, domain-*, etc.)
+- For ownership/borrow/lifetime errors, load the corresponding m0x skill
+- For clippy errors or code review, load the relevant skill (e.g., coding-guidelines, m15-anti-pattern)
+
+## Plan-First Rule
+
+For changes touching **3 or more files** or introducing **new architectural patterns**:
+
+1. **Enter plan mode first** — use `EnterPlanMode` to explore the codebase and design the approach before writing any code.
+2. **Get the plan approved** — the user must approve before execution begins. The plan is the contract.
+3. **Include a verification strategy** — every plan must answer: "How will we verify this works?" (tests, manual checks, CI gates, etc.)
+4. **Stop if scope drifts** — if the implementation diverges from the approved plan, stop and re-plan rather than improvising.
+
+For small, well-scoped changes (single-file fixes, typo corrections, simple bug fixes), skip planning and execute directly.


### PR DESCRIPTION
## Summary

Restructures the split between `AGENTS.md` and `CLAUDE.md` to follow Anthropic's official guidance on instruction-file layout (https://code.claude.com/docs/en/memory.md): Claude Code reads `CLAUDE.md`, not `AGENTS.md` directly. The sanctioned cross-agent pattern is `AGENTS.md` as the agent-agnostic source of truth, imported via `@AGENTS.md` from `CLAUDE.md`, with Claude Code-specific additions placed below the import. This repo's `CLAUDE.md` already did the import; this change moves the Claude-only content out of `AGENTS.md` to match.

## Changes

- **Dropped `@`-imports of `README.md` and `docs/ARCHITECTURE.md` from `AGENTS.md`.** Claude Code recursively auto-loads `@`-imported files in full on every session start — together these two files are ~925 lines (README.md 325 + docs/ARCHITECTURE.md 600), all loaded unconditionally regardless of relevance to the task at hand. Replaced with plain path references so any agent can still read them on demand instead of eating the token cost every session.
- **Moved "Rust Skills" and "Plan-First Rule" from `AGENTS.md` to `CLAUDE.md`.** Both sections are Claude Code specific: rust-skills is a Claude Code plugin (https://github.com/actionbook/rust-skills), and `EnterPlanMode` is a Claude Code tool. Keeping them in `AGENTS.md` meant agent-agnostic tools that read `AGENTS.md` natively (e.g. OpenAI Codex) would see instructions referencing tools/plugins they don't have. Added a one-line provenance note in `CLAUDE.md` so sessions without the rust-skills plugin know to skip that section.
- **Removed the empty "Known Mistakes & Lessons Learned" placeholder section** from `AGENTS.md` — it had no content and no `Read`/write path populating it.

Net effect: `AGENTS.md` 120 → 97 lines (agent-agnostic content only), `CLAUDE.md` 3 → ~20 lines (import + Claude-specific additions).

## Tests

No behavioral/code changes — documentation only. `make all` (fmt + lint + test) ran via the pre-commit hook and passed at commit time.
