### PR TITLE
docs: add SECURITY.md and enable private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+typemux-cc is pre-1.0 and releases roughly follow `main`. Only the latest
+released version receives security fixes; please upgrade before reporting
+an issue.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately via GitHub's
+[Private Vulnerability Reporting](https://github.com/K-dash/typemux-cc/security/advisories/new),
+not through public issues, discussions, or pull requests.
+
+Include as much of the following as you can:
+
+- Affected version (`typemux-cc --version`) and platform
+- Steps to reproduce, or a minimal example
+- Impact (what an attacker could do)
+
+This is a solo-maintained open source project, so response times are
+best-effort rather than a guaranteed SLA. You'll get an acknowledgment and
+a fix, credit, or explanation once triaged.
+
+## Automated Checks
+
+Every change is checked in CI with [`cargo-deny`](deny.toml) (advisories,
+license, and dependency-source policy), GitHub's Dependency Review, and
+[`zizmor`](https://github.com/zizmorcore/zizmor) (GitHub Actions workflow
+security linting).


### PR DESCRIPTION
## Summary

Adds a root `SECURITY.md` following GitHub's standard security-policy convention, and enables GitHub's Private Vulnerability Reporting feature on the repository so it actually backs what the policy says. This is not a doc-only change — it also changes a repo setting.

## Changes

- **`SECURITY.md` (new):**
  - **Supported Versions** — project is pre-1.0 (currently v0.2.16), so only the latest release is stated as supported.
  - **Reporting a Vulnerability** — directs reporters to GitHub's [Private Vulnerability Reporting](https://github.com/K-dash/typemux-cc/security/advisories/new) instead of public issues/discussions/PRs, and lists what to include in a report. States response times as best-effort (solo-maintained project) rather than committing to an SLA.
  - **Automated Checks** — descriptive section noting the CI tooling that already exists in this repo: `cargo-deny` via `deny.toml`, GitHub's Dependency Review, and `zizmor` for Actions workflow security linting. No new tooling added by this PR.
- **Repository setting:** Private Vulnerability Reporting was disabled on `K-dash/typemux-cc` (verified via `gh api repos/K-dash/typemux-cc/private-vulnerability-reporting` → `{"enabled":false}`). With explicit approval, it was enabled (`gh api --method PUT repos/K-dash/typemux-cc/private-vulnerability-reporting`) and re-verified as `{"enabled":true}`. Without this, the link in `SECURITY.md` would 404 for reporters.

## Tests

Docs-only content change; no build/test suite applies. Verified the repository setting change directly via the GitHub API (`gh api repos/K-dash/typemux-cc/private-vulnerability-reporting` before and after).