### PR TITLE
ci: remove markdown paths-ignore so required checks always trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "*.md"
   pull_request:
-    paths-ignore:
-      - "*.md"
 
 # Dedupe superseded runs. Group by PR number (not head_ref: branch names are
 # not unique across forks, so two PRs from different forks with the same

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,8 +6,6 @@ name: Dependency Review
 # changes, using GitHub's own dependency-graph view.
 on:
   pull_request:
-    paths-ignore:
-      - "*.md"
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

Doc-only PRs have been silently skipping required CI checks since `paths-ignore: ["*.md"]` was added to `ci.yml` and `dependency-review.yml` (commit 8d12010, "ci: skip CI for markdown file changes", 2026-01-25). The branch protection ruleset on `main` (id 13668521) requires 7 status checks that only these two workflows produce: `Makefile CI (macos-latest)`, `Makefile CI (ubuntu-24.04-arm)`, `Makefile CI (ubuntu-latest)`, `zizmor (Actions security)`, `cargo-deny`, `MSRV`, `Dependency Review`. Any PR touching only `*.md` files never triggers those workflows at all, so GitHub shows the required checks stuck as "Expected — Waiting for status to be reported" forever — the PR can never merge through the normal required-checks gate.

This went unnoticed because the ruleset's `bypass_actors` grants the repository-owner role `bypass_mode: "always"`. Doc-only PRs (e.g. #127, and #128 before this fix) have been merging via admin bypass rather than actually passing CI since 2026-01-25. Confirmed via `gh api repos/K-dash/typemux-cc/commits/<sha>/check-runs` on PR #128: only CodeQL/Analyze(actions)/Analyze(rust) checks were reported — none of the 7 required ones.

## Changes

- `.github/workflows/ci.yml`: removed `paths-ignore: ["*.md"]` from both the `push` and `pull_request` triggers.
- `.github/workflows/dependency-review.yml`: removed `paths-ignore: ["*.md"]` from the `pull_request` trigger.

Net effect: every PR now runs the full required check set (3-platform Makefile CI matrix, zizmor, cargo-deny, MSRV, Dependency Review), including doc-only ones.

### Why remove `paths-ignore` entirely, rather than skip per-job

The alternative would be per-job `if:` conditions that skip the actual work for docs-only diffs while still reporting the required check names as passed/neutral, preserving the original cost-saving intent behind `paths-ignore`. Given this project's size, always running full CI on every PR (including doc-only ones) is an acceptable cost against the added complexity of maintaining those per-job conditions. This was a deliberate tradeoff decision, not an oversight — removing `paths-ignore` entirely was chosen over the conditional-skip approach for simplicity.

## Tests

This PR changes workflow YAML, not markdown, so it triggers CI under both the old and new config — its own diff doesn't reproduce the doc-only bug. What reviewers *can* observe here is all 7 required checks appearing and reporting normally on this PR, which is the same reporting doc-only PRs will now receive. Full verification of the doc-only path itself needs a markdown-only PR after this merges.

Note: #128 was already merged via the same admin-bypass mechanism, as an interim, explicit, user-approved decision, before this fix was written. This PR fixes the underlying config so future doc-only PRs don't need that workaround.
