### PR TITLE
fix: bound LSP frame and header sizes to contain runaway backends

### DIFF
--- a/src/backend_pool.rs
+++ b/src/backend_pool.rs
@@ -279,6 +279,20 @@ pub struct CreatingEntry {
     /// `creation_rx` completion handler on success, or answered/dropped on
     /// failure — never delivered by a batch loop (see ARCHITECTURE.md).
     pub queued: Vec<RpcMessage>,
+    /// Set by `dispatch_creating_backend_message`'s `Err` arm when the
+    /// reader task reports a read failure (e.g. a framing error, #106)
+    /// while this venv is still Creating. First error wins.
+    ///
+    /// The reader task's `BackendMessage` is a one-shot signal: it's sent
+    /// once, then the task exits. If that message is consumed HERE (while
+    /// Creating) rather than later via the Ready-state crash-cleanup path,
+    /// nothing else will ever report the death — `handle_creation_outcome`'s
+    /// own liveness checks (`try_wait`, `reader_task.is_finished()`) can't
+    /// retroactively see a message that was already drained from the
+    /// channel. Recording it here instead of just logging closes that gap:
+    /// `handle_creation_outcome` consults this field before trusting an
+    /// `Ok` creation result.
+    pub reader_error: Option<BackendError>,
 }
 
 impl CreatingEntry {
@@ -286,6 +300,7 @@ impl CreatingEntry {
         Self {
             session,
             queued: Vec::new(),
+            reader_error: None,
         }
     }
 

--- a/src/bin/mock-lsp-backend.rs
+++ b/src/bin/mock-lsp-backend.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::process;
 use tokio::io;
+use tokio::io::AsyncWriteExt;
 use typemux_cc::error::FramingError;
 use typemux_cc::framing::{LspFrameReader, LspFrameWriter};
 use typemux_cc::message::RpcMessage;
@@ -37,11 +38,24 @@ struct Expect {
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum Action {
-    Respond { body: Value },
-    Notify { method: String, params: Value },
-    SleepMs { ms: u64 },
+    Respond {
+        body: Value,
+    },
+    Notify {
+        method: String,
+        params: Value,
+    },
+    SleepMs {
+        ms: u64,
+    },
     Crash,
     Eof,
+    /// Write raw bytes to stdout, bypassing LSP framing entirely. For
+    /// scripting a malformed/oversized frame (e.g. a `Content-Length` past
+    /// the proxy's framing limit) to test containment (#106).
+    RawBytes {
+        data: String,
+    },
 }
 
 // ── Main ────────────────────────────────────────────────────────────
@@ -181,6 +195,20 @@ async fn execute_action<W: tokio::io::AsyncWrite + Unpin>(
             // Close stdout and exit cleanly.
             drop(std::io::stdout());
             process::exit(0);
+        }
+        Action::RawBytes { data } => {
+            writer
+                .get_mut()
+                .write_all(data.as_bytes())
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!("mock-lsp-backend: write error: {e}");
+                    process::exit(1);
+                });
+            writer.get_mut().flush().await.unwrap_or_else(|e| {
+                eprintln!("mock-lsp-backend: flush error: {e}");
+                process::exit(1);
+            });
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,18 @@ pub enum FramingError {
     #[error("Invalid Content-Length value")]
     InvalidContentLength,
 
+    #[error("Duplicate Content-Length header")]
+    DuplicateContentLength,
+
+    #[error("Content-Length {actual} exceeds maximum frame size of {limit} bytes")]
+    ContentLengthTooLarge { limit: usize, actual: usize },
+
+    #[error("Header line exceeds maximum length of {limit} bytes")]
+    HeaderLineTooLong { limit: usize },
+
+    #[error("Header block exceeds maximum total size of {limit} bytes")]
+    HeaderBlockTooLarge { limit: usize },
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/src/framing.rs
+++ b/src/framing.rs
@@ -4,6 +4,26 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWrite
 
 const CONTENT_LENGTH: &str = "Content-Length: ";
 
+/// Maximum accepted `Content-Length` (message body size). Generous enough
+/// for large `workspace/symbol` fan-out merges, but bounded so a corrupt or
+/// misbehaving backend declaring a huge size can't make the proxy commit an
+/// unbounded allocation (#106). Checked before `vec![0u8; content_length]`
+/// is ever created.
+const MAX_CONTENT_LENGTH: usize = 64 * 1024 * 1024; // 64 MiB
+
+/// Maximum length of a single header line (including its `\r\n`
+/// terminator). Real LSP header lines (`Content-Length: N`, an optional
+/// `Content-Type: ...`) are a few dozen bytes; this is generous headroom
+/// while still bounding a peer that streams a line with no `\n` from
+/// growing the line buffer without limit.
+const MAX_HEADER_LINE_LEN: usize = 8 * 1024; // 8 KiB
+
+/// Maximum total size of the header block (sum of all header line lengths
+/// before the terminating blank line). LSP frames carry at most two headers;
+/// this bounds a peer that never sends the terminating blank line from
+/// making `read_headers` accumulate lines forever.
+const MAX_HEADER_BLOCK_LEN: usize = 64 * 1024; // 64 KiB
+
 /// LSP frame reader
 pub struct LspFrameReader<R> {
     reader: BufReader<R>,
@@ -33,17 +53,24 @@ impl<R: AsyncRead + Unpin> LspFrameReader<R> {
 
     async fn read_headers(&mut self) -> Result<usize, FramingError> {
         let mut content_length: Option<usize> = None;
+        let mut total_header_bytes: usize = 0;
 
         loop {
-            let mut line = String::new();
-            let bytes_read = self.reader.read_line(&mut line).await?;
+            let line = self.read_header_line().await?;
 
-            // Detect EOF (read_line returns 0)
-            if bytes_read == 0 {
+            // Detect EOF (empty line at a line boundary)
+            if line.is_empty() {
                 return Err(FramingError::Io(std::io::Error::new(
                     std::io::ErrorKind::UnexpectedEof,
                     "EOF while reading headers",
                 )));
+            }
+
+            total_header_bytes += line.len();
+            if total_header_bytes > MAX_HEADER_BLOCK_LEN {
+                return Err(FramingError::HeaderBlockTooLarge {
+                    limit: MAX_HEADER_BLOCK_LEN,
+                });
             }
 
             // Empty line (\r\n only) marks end of headers
@@ -54,16 +81,63 @@ impl<R: AsyncRead + Unpin> LspFrameReader<R> {
             // Parse Content-Length header
             let line = line.trim();
             if let Some(len_str) = line.strip_prefix(CONTENT_LENGTH) {
-                content_length = Some(
-                    len_str
-                        .parse()
-                        .map_err(|_| FramingError::InvalidContentLength)?,
-                );
+                if content_length.is_some() {
+                    return Err(FramingError::DuplicateContentLength);
+                }
+                let parsed: usize = len_str
+                    .parse()
+                    .map_err(|_| FramingError::InvalidContentLength)?;
+                if parsed > MAX_CONTENT_LENGTH {
+                    return Err(FramingError::ContentLengthTooLarge {
+                        limit: MAX_CONTENT_LENGTH,
+                        actual: parsed,
+                    });
+                }
+                content_length = Some(parsed);
             }
             // Ignore Content-Type (assume UTF-8)
         }
 
         content_length.ok_or(FramingError::MissingContentLength)
+    }
+
+    /// Read one header line, including its trailing `\n`, capped at
+    /// `MAX_HEADER_LINE_LEN` bytes. Returns an empty string on EOF at a line
+    /// boundary (mirrors `AsyncBufReadExt::read_line`'s contract, which the
+    /// caller relies on to detect a closed backend/client stream).
+    ///
+    /// Implemented directly against `fill_buf`/`consume` rather than
+    /// `read_line` because `read_line` has no size cap: a peer that streams
+    /// bytes with no `\n` would make it grow the `String` without bound.
+    /// Each `fill_buf` call returns at most the `BufReader`'s internal
+    /// capacity worth of bytes, so the cap below is enforced before a chunk
+    /// is appended, not after the line has already grown past it.
+    async fn read_header_line(&mut self) -> Result<String, FramingError> {
+        let mut line = Vec::new();
+        loop {
+            let available = self.reader.fill_buf().await?;
+            if available.is_empty() {
+                break; // EOF
+            }
+
+            let newline_pos = available.iter().position(|&b| b == b'\n');
+            let chunk_len = newline_pos.map_or(available.len(), |pos| pos + 1);
+
+            if line.len() + chunk_len > MAX_HEADER_LINE_LEN {
+                return Err(FramingError::HeaderLineTooLong {
+                    limit: MAX_HEADER_LINE_LEN,
+                });
+            }
+            line.extend_from_slice(&available[..chunk_len]);
+            self.reader.consume(chunk_len);
+
+            if newline_pos.is_some() {
+                break;
+            }
+        }
+
+        String::from_utf8(line)
+            .map_err(|e| FramingError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)))
     }
 }
 
@@ -122,5 +196,89 @@ mod tests {
         let msg = RpcMessage::request(crate::message::RpcId::Number(1), "test", None);
         writer.write_message(&msg).await.unwrap();
         assert!(output.starts_with(b"Content-Length: "));
+    }
+
+    /// A `Content-Length` above the limit must be rejected before the body
+    /// buffer is ever allocated. `usize::MAX` is deliberately extreme: if
+    /// the check were bypassed, `vec![0u8; content_length]` would panic
+    /// with a capacity overflow immediately rather than slowly exhausting
+    /// memory — a fast, deterministic way to prove the check runs first.
+    #[tokio::test]
+    async fn test_oversized_content_length_rejected_without_allocation() {
+        let input = format!("Content-Length: {}\r\n\r\n", usize::MAX);
+        let mut reader = LspFrameReader::new(input.as_bytes());
+        let err = reader.read_message().await.unwrap_err();
+        match err {
+            FramingError::ContentLengthTooLarge { limit, actual } => {
+                assert_eq!(limit, MAX_CONTENT_LENGTH);
+                assert_eq!(actual, usize::MAX);
+            }
+            other => panic!("expected ContentLengthTooLarge, got {other:?}"),
+        }
+    }
+
+    /// A frame declaring exactly `MAX_CONTENT_LENGTH` — the boundary the
+    /// oversized check must NOT reject — still parses successfully.
+    #[tokio::test]
+    async fn test_content_length_at_limit_still_parses() {
+        let prefix = r#"{"jsonrpc":"2.0","params":{"pad":""#;
+        let suffix = r#""}}"#;
+        let pad_len = MAX_CONTENT_LENGTH - prefix.len() - suffix.len();
+        let content = format!("{prefix}{}{suffix}", "a".repeat(pad_len));
+        assert_eq!(content.len(), MAX_CONTENT_LENGTH);
+
+        let mut input = format!("Content-Length: {MAX_CONTENT_LENGTH}\r\n\r\n").into_bytes();
+        input.extend_from_slice(content.as_bytes());
+
+        let mut reader = LspFrameReader::new(&input[..]);
+        let msg = reader.read_message().await.unwrap();
+        assert_eq!(msg.jsonrpc, "2.0");
+    }
+
+    /// A single header line far beyond `MAX_HEADER_LINE_LEN` is rejected —
+    /// well over any plausible `BufReader` chunk size, so the cap fires
+    /// regardless of internal buffering boundaries.
+    #[tokio::test]
+    async fn test_oversized_header_line_rejected() {
+        let long_line = format!("X-Padding: {}", "a".repeat(MAX_HEADER_LINE_LEN * 2));
+        let input = format!("{long_line}\r\nContent-Length: 5\r\n\r\nhello");
+        let mut reader = LspFrameReader::new(input.as_bytes());
+        let err = reader.read_message().await.unwrap_err();
+        match err {
+            FramingError::HeaderLineTooLong { limit } => assert_eq!(limit, MAX_HEADER_LINE_LEN),
+            other => panic!("expected HeaderLineTooLong, got {other:?}"),
+        }
+    }
+
+    /// Many header lines, each individually under `MAX_HEADER_LINE_LEN`, but
+    /// whose total exceeds `MAX_HEADER_BLOCK_LEN`, are rejected — proves the
+    /// total-block cap is enforced independently of the per-line cap.
+    #[tokio::test]
+    async fn test_oversized_header_block_rejected() {
+        let line = format!("X-Pad: {}\r\n", "a".repeat(64));
+        assert!(line.len() < MAX_HEADER_LINE_LEN);
+        let count = MAX_HEADER_BLOCK_LEN / line.len() + 2;
+
+        let mut input = String::with_capacity(line.len() * count);
+        for _ in 0..count {
+            input.push_str(&line);
+        }
+
+        let mut reader = LspFrameReader::new(input.as_bytes());
+        let err = reader.read_message().await.unwrap_err();
+        match err {
+            FramingError::HeaderBlockTooLarge { limit } => assert_eq!(limit, MAX_HEADER_BLOCK_LEN),
+            other => panic!("expected HeaderBlockTooLarge, got {other:?}"),
+        }
+    }
+
+    /// A second `Content-Length` header is an explicit error, not a
+    /// last-wins/first-wins implicit resolution.
+    #[tokio::test]
+    async fn test_duplicate_content_length_rejected() {
+        let input = b"Content-Length: 10\r\nContent-Length: 20\r\n\r\n0123456789";
+        let mut reader = LspFrameReader::new(&input[..]);
+        let err = reader.read_message().await.unwrap_err();
+        assert!(matches!(err, FramingError::DuplicateContentLength));
     }
 }

--- a/src/framing.rs
+++ b/src/framing.rs
@@ -18,10 +18,10 @@ const MAX_CONTENT_LENGTH: usize = 64 * 1024 * 1024; // 64 MiB
 /// growing the line buffer without limit.
 const MAX_HEADER_LINE_LEN: usize = 8 * 1024; // 8 KiB
 
-/// Maximum total size of the header block (sum of all header line lengths
-/// before the terminating blank line). LSP frames carry at most two headers;
-/// this bounds a peer that never sends the terminating blank line from
-/// making `read_headers` accumulate lines forever.
+/// Maximum total size of the header block (sum of all header line lengths,
+/// including the terminating blank line itself). LSP frames carry at most
+/// two headers; this bounds a peer that never sends the terminating blank
+/// line from making `read_headers` accumulate lines forever.
 const MAX_HEADER_BLOCK_LEN: usize = 64 * 1024; // 64 KiB
 
 /// LSP frame reader
@@ -218,21 +218,15 @@ mod tests {
     }
 
     /// A frame declaring exactly `MAX_CONTENT_LENGTH` — the boundary the
-    /// oversized check must NOT reject — still parses successfully.
+    /// oversized check must NOT reject — is accepted by `read_headers`.
+    /// Calls `read_headers` directly rather than `read_message`, so the
+    /// boundary check is exercised without materializing a 64 MiB body.
     #[tokio::test]
     async fn test_content_length_at_limit_still_parses() {
-        let prefix = r#"{"jsonrpc":"2.0","params":{"pad":""#;
-        let suffix = r#""}}"#;
-        let pad_len = MAX_CONTENT_LENGTH - prefix.len() - suffix.len();
-        let content = format!("{prefix}{}{suffix}", "a".repeat(pad_len));
-        assert_eq!(content.len(), MAX_CONTENT_LENGTH);
-
-        let mut input = format!("Content-Length: {MAX_CONTENT_LENGTH}\r\n\r\n").into_bytes();
-        input.extend_from_slice(content.as_bytes());
-
-        let mut reader = LspFrameReader::new(&input[..]);
-        let msg = reader.read_message().await.unwrap();
-        assert_eq!(msg.jsonrpc, "2.0");
+        let input = format!("Content-Length: {MAX_CONTENT_LENGTH}\r\n\r\n");
+        let mut reader = LspFrameReader::new(input.as_bytes());
+        let content_length = reader.read_headers().await.unwrap();
+        assert_eq!(content_length, MAX_CONTENT_LENGTH);
     }
 
     /// A single header line far beyond `MAX_HEADER_LINE_LEN` is rejected —

--- a/src/proxy/backend_dispatch.rs
+++ b/src/proxy/backend_dispatch.rs
@@ -76,7 +76,7 @@ impl super::LspProxy {
     /// converges once the backend is `Ready`). So "the normal notification
     /// path" for this window is simply: forward it.
     async fn dispatch_creating_backend_message(
-        &self,
+        &mut self,
         venv_path: PathBuf,
         session: u64,
         result: Result<RpcMessage, BackendError>,
@@ -104,18 +104,24 @@ impl super::LspProxy {
                 // The backend's reader task died mid-creation. `pool.creating`'s
                 // entry is owned by the `creation_rx` completion handler, not
                 // this crash-cleanup path (which only operates on `backends`)
-                // — the completion handler's own liveness check catches this
-                // and reports it as a contained creation failure, whether the
-                // process itself died (`try_wait`) or only the reader task did
-                // while the process stayed alive (`reader_task.is_finished()`,
-                // #106 — a framing error, or any other read failure, leaves a
-                // live process with nothing left to drain its stdout).
+                // — the completion handler's own liveness checks catch this:
+                // the process itself dying (`try_wait`), the reader task's own
+                // `JoinHandle` finishing (`is_finished()`) with the process
+                // still alive, or — this arm's own contribution — this exact
+                // error, recorded onto `CreatingEntry::reader_error` below so
+                // it isn't lost by being consumed (and, before this fix,
+                // merely logged) here instead of reaching that check. #106.
                 tracing::debug!(
                     venv = %venv_path.display(),
                     session = session,
                     error = ?e,
-                    "Backend read error during creation; completion handler will report the outcome"
+                    "Backend read error during creation; recording onto the entry for the completion handler"
                 );
+                if let Some(entry) = self.state.pool.creating_get_mut(&venv_path) {
+                    if entry.reader_error.is_none() {
+                        entry.reader_error = Some(e);
+                    }
+                }
             }
         }
         Ok(())

--- a/src/proxy/backend_dispatch.rs
+++ b/src/proxy/backend_dispatch.rs
@@ -101,11 +101,15 @@ impl super::LspProxy {
                 );
             }
             Err(e) => {
-                // The backend died mid-creation. `pool.creating`'s entry is
-                // owned by the `creation_rx` completion handler, not this
-                // crash-cleanup path (which only operates on `backends`) —
-                // the completion handler's own liveness check catches this
-                // and reports it as a contained creation failure.
+                // The backend's reader task died mid-creation. `pool.creating`'s
+                // entry is owned by the `creation_rx` completion handler, not
+                // this crash-cleanup path (which only operates on `backends`)
+                // — the completion handler's own liveness check catches this
+                // and reports it as a contained creation failure, whether the
+                // process itself died (`try_wait`) or only the reader task did
+                // while the process stayed alive (`reader_task.is_finished()`,
+                // #106 — a framing error, or any other read failure, leaves a
+                // live process with nothing left to drain its stdout).
                 tracing::debug!(
                     venv = %venv_path.display(),
                     session = session,

--- a/src/proxy/pool_management.rs
+++ b/src/proxy/pool_management.rs
@@ -219,60 +219,14 @@ impl super::LspProxy {
     ) -> Result<(), ProxyError> {
         let CreationOutcome { venv_path, result } = outcome;
 
-        let Some(entry) = self.state.pool.creating_remove(&venv_path) else {
+        let Some(mut entry) = self.state.pool.creating_remove(&venv_path) else {
             // Defensive: no other code path removes `creating` entries.
             tracing::warn!(venv = %venv_path.display(), "Creation outcome for an untracked venv, ignoring");
             return Ok(());
         };
 
         let result = match result {
-            // A restoration write failure already fails creation before this
-            // point (see `write_restored_documents`), but a backend can also
-            // die *without* any write failing — e.g. every write lands in
-            // the OS pipe buffer moments before the process exits. Check
-            // liveness before trusting `Ok`. This narrows but doesn't close
-            // the race: the process could still die in the instant after
-            // `try_wait`, same residual window a `Ready` backend already
-            // lives with (caught on its next read/write instead).
-            //
-            // `try_wait` only detects the PROCESS dying. A backend can also
-            // emit a malformed/oversized frame (#106) — or, pre-dating that
-            // fix, a bare `MissingContentLength` from a backend that dies
-            // mid-write — while staying alive: the reader task
-            // (`spawn_reader_task`) hits the framing error and exits, but
-            // `try_wait` still reports the process as running. Without this
-            // second check, such an instance would be pooled `Ready` with no
-            // task left to ever drain its stdout, and every subsequent
-            // request against it would write into the pipe and hang forever
-            // waiting for a response nobody reads. `is_finished()` catches
-            // that: the reader task is gone, so this is a dead backend
-            // regardless of what the OS process is doing.
-            Ok(mut instance) => match instance.child.try_wait() {
-                Ok(None) => {
-                    if instance.reader_task.is_finished() {
-                        instance.reader_task.abort();
-                        Err(ProxyError::Backend(BackendError::InitializeFailed(
-                            "backend reader task exited during creation (framing error) \
-                             while the process is still alive"
-                                .to_string(),
-                        )))
-                    } else {
-                        Ok(instance)
-                    }
-                }
-                Ok(Some(status)) => {
-                    instance.reader_task.abort();
-                    Err(ProxyError::Backend(BackendError::InitializeFailed(
-                        format!("backend process exited during creation ({status})"),
-                    )))
-                }
-                Err(io_err) => {
-                    instance.reader_task.abort();
-                    Err(ProxyError::Backend(BackendError::InitializeFailed(
-                        format!("failed to check backend liveness after creation: {io_err}"),
-                    )))
-                }
-            },
+            Ok(instance) => check_creation_liveness(instance, entry.reader_error.take()),
             Err(e) => Err(e),
         };
 
@@ -784,5 +738,160 @@ impl super::LspProxy {
         }
 
         Ok(())
+    }
+}
+
+/// Decide whether a freshly created backend instance is actually healthy
+/// enough to pool, given every liveness signal available at this point.
+/// Pure and synchronous (no `.await`) so it's deterministically unit
+/// testable — extracted for exactly that reason, mirroring
+/// `backend_dispatch::classify_session`.
+///
+/// Three ways a reader can be dead by the time this runs, all converging on
+/// the same containment failure:
+///
+/// 1. `reader_error` is `Some`: `dispatch_creating_backend_message`'s `Err`
+///    arm already consumed the reader task's one-shot `BackendMessage` from
+///    `backend_msg_rx` while this venv was still `Creating`, and recorded it
+///    onto `CreatingEntry::reader_error` instead of just logging it. This is
+///    the ordering `try_wait`/`is_finished()` alone cannot see: if the main
+///    loop drains that channel message and THEN processes this creation
+///    outcome — all within one scheduler tick, before the reader task's own
+///    `JoinHandle` has been polled again to actually transition to
+///    "finished" — `is_finished()` would still read `false` even though the
+///    backend is unambiguously dead. Checked first, and unconditionally
+///    decisive: no live-process signal can override an error that was
+///    already observed.
+/// 2. `try_wait` reports the process exited: the reader task's message may
+///    or may not have been consumed yet, but the process itself is
+///    unarguably gone.
+/// 3. `try_wait` reports the process alive, but `reader_task.is_finished()`
+///    is `true`: the reader died (e.g. panicked, or its `send` raced ahead
+///    of the main loop ever polling `backend_msg_rx` before this check ran)
+///    without its message having been consumed via path 1.
+///
+/// If none of the three fire, the instance is genuinely healthy: `Ok`.
+///
+/// The one case this still doesn't close (documented, not fixed here,
+/// same as before #106): the reader task's error hasn't been sent, consumed,
+/// nor has its `JoinHandle` finished, by the time this check runs — i.e. the
+/// backend dies in the instant right after this check passes. That's the
+/// same residual window a `Ready` backend already lives with every day
+/// (caught on its next read/write instead, via the ordinary crash-cleanup
+/// path in `backend_dispatch::dispatch_ready_backend_message`).
+fn check_creation_liveness(
+    mut instance: BackendInstance,
+    reader_error: Option<BackendError>,
+) -> Result<BackendInstance, ProxyError> {
+    if let Some(reader_err) = reader_error {
+        instance.reader_task.abort();
+        return Err(ProxyError::Backend(BackendError::InitializeFailed(
+            format!("backend reader task exited during creation: {reader_err}"),
+        )));
+    }
+
+    match instance.child.try_wait() {
+        Ok(None) => {
+            if !instance.reader_task.is_finished() {
+                return Ok(instance);
+            }
+            instance.reader_task.abort();
+            Err(ProxyError::Backend(BackendError::InitializeFailed(
+                "backend reader task exited during creation (framing error) \
+                 while the process is still alive"
+                    .to_string(),
+            )))
+        }
+        Ok(Some(status)) => {
+            instance.reader_task.abort();
+            Err(ProxyError::Backend(BackendError::InitializeFailed(
+                format!("backend process exited during creation ({status})"),
+            )))
+        }
+        Err(io_err) => {
+            instance.reader_task.abort();
+            Err(ProxyError::Backend(BackendError::InitializeFailed(
+                format!("failed to check backend liveness after creation: {io_err}"),
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_creation_liveness;
+    use crate::backend_pool::BackendInstance;
+    use crate::error::BackendError;
+    use crate::framing::LspFrameWriter;
+    use std::path::PathBuf;
+    use std::process::Stdio;
+    use tokio::process::Command;
+
+    /// Spawn a genuinely live helper process and a genuinely unfinished
+    /// reader task, so `try_wait`/`is_finished()` alone would both say
+    /// "healthy" — isolates the `reader_error` branch specifically. Not
+    /// `async` itself (no `.await` at this level — `Command::spawn` is
+    /// synchronous and `tokio::spawn` just needs an active runtime, which
+    /// the `#[tokio::test]` callers already provide).
+    fn live_instance() -> BackendInstance {
+        let mut child = Command::new("/bin/sh")
+            .arg("-c")
+            .arg("sleep 5")
+            .stdin(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("failed to spawn helper process");
+        let stdin = child.stdin.take().expect("child stdin should be piped");
+        let writer = LspFrameWriter::new(stdin);
+        let reader_task = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        });
+
+        BackendInstance::from_parts(
+            writer,
+            child,
+            1,
+            reader_task,
+            PathBuf::from("/fake/venv"),
+            1,
+            None,
+        )
+    }
+
+    /// A recorded `reader_error` fails creation even when both other
+    /// liveness signals (`try_wait`, `is_finished()`) say the backend is
+    /// healthy — proves the ordering `is_finished()` alone can't close (see
+    /// `check_creation_liveness`'s doc comment, case 1) is actually closed.
+    ///
+    /// Detection power: reverting the `reader_error` consultation (making
+    /// this function ignore its second argument) makes this test fail,
+    /// since `try_wait` and `is_finished()` alone both report healthy here.
+    #[tokio::test]
+    async fn check_creation_liveness_reader_error_fails_even_when_process_and_reader_are_alive() {
+        let instance = live_instance();
+        let reader_error = Some(BackendError::InitializeFailed(
+            "simulated framing error".to_string(),
+        ));
+
+        let result = check_creation_liveness(instance, reader_error);
+
+        assert!(
+            result.is_err(),
+            "a recorded reader_error must fail creation regardless of try_wait/is_finished"
+        );
+    }
+
+    /// No recorded error, process alive, reader task not finished: the
+    /// ordinary healthy path.
+    #[tokio::test]
+    async fn check_creation_liveness_healthy_when_no_error_recorded() {
+        let instance = live_instance();
+
+        let result = check_creation_liveness(instance, None);
+
+        assert!(
+            result.is_ok(),
+            "a live process with no recorded error and an unfinished reader should be pooled"
+        );
     }
 }

--- a/src/proxy/pool_management.rs
+++ b/src/proxy/pool_management.rs
@@ -797,7 +797,7 @@ fn check_creation_liveness(
             }
             instance.reader_task.abort();
             Err(ProxyError::Backend(BackendError::InitializeFailed(
-                "backend reader task exited during creation (framing error) \
+                "backend reader task exited during creation \
                  while the process is still alive"
                     .to_string(),
             )))

--- a/src/proxy/pool_management.rs
+++ b/src/proxy/pool_management.rs
@@ -234,8 +234,32 @@ impl super::LspProxy {
             // the race: the process could still die in the instant after
             // `try_wait`, same residual window a `Ready` backend already
             // lives with (caught on its next read/write instead).
+            //
+            // `try_wait` only detects the PROCESS dying. A backend can also
+            // emit a malformed/oversized frame (#106) — or, pre-dating that
+            // fix, a bare `MissingContentLength` from a backend that dies
+            // mid-write — while staying alive: the reader task
+            // (`spawn_reader_task`) hits the framing error and exits, but
+            // `try_wait` still reports the process as running. Without this
+            // second check, such an instance would be pooled `Ready` with no
+            // task left to ever drain its stdout, and every subsequent
+            // request against it would write into the pipe and hang forever
+            // waiting for a response nobody reads. `is_finished()` catches
+            // that: the reader task is gone, so this is a dead backend
+            // regardless of what the OS process is doing.
             Ok(mut instance) => match instance.child.try_wait() {
-                Ok(None) => Ok(instance),
+                Ok(None) => {
+                    if instance.reader_task.is_finished() {
+                        instance.reader_task.abort();
+                        Err(ProxyError::Backend(BackendError::InitializeFailed(
+                            "backend reader task exited during creation (framing error) \
+                             while the process is still alive"
+                                .to_string(),
+                        )))
+                    } else {
+                        Ok(instance)
+                    }
+                }
                 Ok(Some(status)) => {
                     instance.reader_task.abort();
                     Err(ProxyError::Backend(BackendError::InitializeFailed(

--- a/tests/oversized_frame_containment_test.rs
+++ b/tests/oversized_frame_containment_test.rs
@@ -168,3 +168,177 @@ async fn oversized_frame_from_backend_is_contained_e2e() {
         "shutdown should not return an error"
     );
 }
+
+/// E2E (#106 review fix, #96 AC3 containment): a malformed/oversized frame
+/// from a backend during the Creating window — with the backend PROCESS
+/// staying alive — must not pool a zombie `Ready` instance whose reader task
+/// is already dead.
+///
+/// Before this fix, `handle_creation_outcome`'s liveness check was
+/// `child.try_wait()` only: a dead reader task on a live process (a framing
+/// error, or any other read failure — this zombie class predates #106, e.g.
+/// a bare `MissingContentLength` from a backend that dies mid-write, but
+/// #106's new size limits make it far more reachable) slipped through as
+/// `Ok(None)` and the instance was pooled `Ready` with nothing left to ever
+/// drain its stdout — every subsequent request against it would write into
+/// the pipe and hang forever waiting for a response nobody reads.
+///
+/// The restoration `didOpen` (queued by opening `zombie/main.py`, which also
+/// starts creation and is captured in the snapshot the creation task
+/// restores) gets a malformed frame in response instead of silence. The
+/// mock process is deliberately NOT scripted to exit afterward — it must
+/// stay alive so `try_wait` alone would report the backend as healthy;
+/// `reader_task.is_finished()` is what has to catch this.
+#[tokio::test]
+async fn zombie_reader_during_creating_is_not_pooled_e2e() {
+    let scenario_good = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover good sync" } } }]
+            },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover good again" } } }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+
+    // Slow handshake (mirrors cold_spawn_does_not_block_warm_venv_e2e):
+    // gives the "good" venv's traffic a comfortable window to prove it's
+    // unblocked while "zombie" is still Creating. No further steps after
+    // the restoration didOpen — the mock falls into its drain loop and
+    // stays alive, since it's never scripted to crash or exit.
+    let scenario_zombie = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [
+                    { "type": "sleep_ms", "ms": 300 },
+                    { "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }
+                ]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/didOpen" },
+                "actions": [{ "type": "raw_bytes", "data": "Content-Length: 999999999999\r\n\r\n" }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![
+            PackageConfig {
+                name: "good".to_string(),
+                scenario: scenario_good,
+                has_venv: true,
+            },
+            PackageConfig {
+                name: "zombie".to_string(),
+                scenario: scenario_zombie,
+                has_venv: true,
+            },
+        ],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    let mut proxy = ProxyUnderTest::spawn(temp_dir, root.clone(), &root);
+
+    let root_uri = support::path_to_uri(&root);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file_good = root.join("good/main.py");
+    std::fs::write(&file_good, "a = 1\n").unwrap();
+    let file_good_uri = support::path_to_uri(&file_good);
+    proxy.did_open(&file_good_uri, "a = 1\n").await;
+
+    let hover_good_params = || {
+        serde_json::json!({
+            "textDocument": { "uri": &file_good_uri },
+            "position": { "line": 0, "character": 0 }
+        })
+    };
+    let sync_good = proxy
+        .request("textDocument/hover", hover_good_params())
+        .await;
+    assert!(
+        sync_good.error.is_none(),
+        "sync hover(good) failed: {:?}",
+        sync_good.error
+    );
+
+    // Opening a document under "zombie" starts its creation (300ms
+    // handshake); restoration writes this didOpen back to it, and the mock
+    // answers with a malformed frame right after.
+    let file_zombie = root.join("zombie/main.py");
+    std::fs::write(&file_zombie, "z = 1\n").unwrap();
+    let file_zombie_uri = support::path_to_uri(&file_zombie);
+    proxy.did_open(&file_zombie_uri, "z = 1\n").await;
+
+    // Un-awaited: queues behind the in-flight (and soon-to-be-contained) creation.
+    let zombie_hover_params = serde_json::json!({
+        "textDocument": { "uri": &file_zombie_uri },
+        "position": { "line": 0, "character": 0 }
+    });
+    let zombie_id = proxy
+        .send_request("textDocument/hover", zombie_hover_params)
+        .await;
+
+    // The good venv must stay unaffected regardless of the zombie's outcome.
+    let hover_good2 = proxy
+        .request("textDocument/hover", hover_good_params())
+        .await;
+    assert!(
+        hover_good2.error.is_none(),
+        "hover(good) failed: {:?}",
+        hover_good2.error
+    );
+    assert_eq!(
+        hover_good2.result.as_ref().unwrap()["contents"]["value"],
+        "hover good again"
+    );
+
+    // The zombie venv's queued request must get an explicit error — not a
+    // hang, which is what forwarding into a backend with a dead reader task
+    // would cause (nothing left to ever drain a response out of the pipe).
+    // Either race path (see the doc comment above) produces a distinct but
+    // equally explicit message: `handle_creation_outcome`'s new
+    // `is_finished()` check says "backend error" (creation-failure path);
+    // if the reader's error is instead observed after the instance was
+    // already pooled `Ready` (the residual race `handle_creation_outcome`'s
+    // own liveness-check comment already documents as unclosed), the
+    // pre-existing crash-cleanup path says "cancelled due to backend
+    // eviction" — same observable property, different message text.
+    let zombie_resp = proxy.wait_for_response(zombie_id, 5000).await;
+    let error = zombie_resp
+        .error
+        .expect("queued hover against a backend with a dead reader must fail explicitly, not hang");
+    assert!(
+        error.message.contains("backend error") || error.message.contains("cancelled"),
+        "expected an explicit backend-death error, got: {}",
+        error.message
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}

--- a/tests/oversized_frame_containment_test.rs
+++ b/tests/oversized_frame_containment_test.rs
@@ -1,0 +1,170 @@
+mod support;
+
+use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
+
+/// E2E (#106, #92 containment): a backend that becomes `Ready` and answers
+/// one request normally, then emits a raw frame declaring a `Content-Length`
+/// far beyond the framing limit, is contained — the reader task's framing
+/// error routes through the existing crash-cleanup path
+/// (`handle_backend_crash`, unchanged by this fix), evicting just that
+/// backend, while a second, healthy venv keeps serving normally.
+///
+/// The garbage bytes are appended as a second action on the same step that
+/// answers the hover request (not tied to any further client message): the
+/// reader task, already looping in the background per
+/// `backend_pool::spawn_reader_task`, picks it up on its own next read.
+#[tokio::test]
+async fn oversized_frame_from_backend_is_contained_e2e() {
+    let scenario_good = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover good sync" } } }]
+            },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover good again" } } }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+
+    // Answers one hover normally (proving it reached Ready and the reader
+    // task is actively draining its stdout), then immediately follows up
+    // with a malformed frame: a Content-Length far past the framing limit,
+    // no body. The proxy must reject it before attempting to allocate or
+    // read a body, and evict this backend without disturbing "good".
+    let scenario_garbage = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [
+                    { "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover garbage sync" } } },
+                    { "type": "raw_bytes", "data": "Content-Length: 999999999999\r\n\r\n" }
+                ]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![
+            PackageConfig {
+                name: "good".to_string(),
+                scenario: scenario_good,
+                has_venv: true,
+            },
+            PackageConfig {
+                name: "garbage".to_string(),
+                scenario: scenario_garbage,
+                has_venv: true,
+            },
+        ],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    let mut proxy = ProxyUnderTest::spawn(temp_dir, root.clone(), &root);
+
+    let root_uri = support::path_to_uri(&root);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file_good = root.join("good/main.py");
+    std::fs::write(&file_good, "a = 1\n").unwrap();
+    let file_good_uri = support::path_to_uri(&file_good);
+    proxy.did_open(&file_good_uri, "a = 1\n").await;
+
+    let hover_good_params = || {
+        serde_json::json!({
+            "textDocument": { "uri": &file_good_uri },
+            "position": { "line": 0, "character": 0 }
+        })
+    };
+    let sync_good = proxy
+        .request("textDocument/hover", hover_good_params())
+        .await;
+    assert!(
+        sync_good.error.is_none(),
+        "sync hover(good) failed: {:?}",
+        sync_good.error
+    );
+
+    let file_garbage = root.join("garbage/main.py");
+    std::fs::write(&file_garbage, "g = 1\n").unwrap();
+    let file_garbage_uri = support::path_to_uri(&file_garbage);
+    proxy.did_open(&file_garbage_uri, "g = 1\n").await;
+
+    let hover_garbage = proxy
+        .request(
+            "textDocument/hover",
+            serde_json::json!({
+                "textDocument": { "uri": &file_garbage_uri },
+                "position": { "line": 0, "character": 0 }
+            }),
+        )
+        .await;
+    assert!(
+        hover_garbage.error.is_none(),
+        "hover(garbage) sync failed: {:?}",
+        hover_garbage.error
+    );
+    assert_eq!(
+        hover_garbage.result.as_ref().unwrap()["contents"]["value"],
+        "hover garbage sync"
+    );
+
+    // Crash cleanup for the garbage venv: 1 open doc -> 1 empty publishDiagnostics.
+    let notifications = proxy.wait_for_crash_cleanup(1, 5000).await;
+    let diag_count = notifications
+        .iter()
+        .filter(|m| {
+            m.method.as_deref() == Some("textDocument/publishDiagnostics")
+                && m.params.as_ref().and_then(|p| p["uri"].as_str())
+                    == Some(file_garbage_uri.as_str())
+        })
+        .count();
+    assert!(
+        diag_count >= 1,
+        "expected crash cleanup diagnostics for the garbage venv, got {diag_count}"
+    );
+
+    // The good venv must be unaffected by the garbage venv's containment.
+    let hover_good2 = proxy
+        .request("textDocument/hover", hover_good_params())
+        .await;
+    assert!(
+        hover_good2.error.is_none(),
+        "hover(good) after garbage-venv crash failed: {:?}",
+        hover_good2.error
+    );
+    assert_eq!(
+        hover_good2.result.as_ref().unwrap()["contents"]["value"],
+        "hover good again"
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}


### PR DESCRIPTION
## Summary

`read_message` allocated the full declared frame size with no upper bound (`vec![0u8; content_length]` committed immediately), and header reading grew a String with no per-line or total limit. A single corrupt or misbehaving backend emitting garbage could OOM the entire proxy — contradicting the #92 containment principle. Both the client-stdin and every backend-stdout side share this framing.

## Changes

- `src/framing.rs`: three constants (no new config surface) — `MAX_CONTENT_LENGTH` 64 MiB (large `workspace/symbol` fan-out merges must fit), `MAX_HEADER_LINE_LEN` 8 KiB, `MAX_HEADER_BLOCK_LEN` 64 KiB. The Content-Length check runs at header-parse time, before any buffer allocation. Header lines are read via `fill_buf`/`consume` instead of the uncapped `read_line`, so the per-line cap is enforced before a chunk is appended. A duplicate `Content-Length` is an explicit error rather than an implicit first/last-wins.
- `src/error.rs`: four new `FramingError` variants naming the limit and (where applicable) the observed value.
- Containment: a backend reader hitting these errors routes through the existing reader-task-Err → crash-cleanup path (no new machinery); corrupt client stdin still ends the session, unchanged.
- **Zombie-reader containment gap closed** (found by external review during this PR): a backend whose reader died from a framing error while its process stayed alive could be pooled as Ready during the Creating window — `handle_creation_outcome` only checked `child.try_wait()`. This class actually predates this PR (a bare `MissingContentLength` could do it ever since #130); the new limits just made it far more reachable. Fixed in depth across two review rounds: the liveness decision is now a pure `check_creation_liveness()` checking, in order, (1) a `reader_error` recorded on the `CreatingEntry` by the Creating-window dispatch (closes the ordering where the error message is consumed before the reader task is marked finished — a one-scheduler-tick race that stress runs cannot disprove), (2) `try_wait()` for process death, (3) `reader_task.is_finished()` for a reader that died without its message being seen. The ordering analysis is documented on the function.
- `src/bin/mock-lsp-backend.rs`: additive `RawBytes` scenario action to script malformed frames.

## Tests

- Unit (framing): oversized Content-Length rejected WITHOUT allocation (detection power: without the check the test panics on a ~16 EB Vec capacity overflow), boundary 64 MiB accepted via direct `read_headers` (no body materialized), oversized header line, oversized header block, duplicate Content-Length.
- Unit (liveness): `check_creation_liveness` proven decisive on a recorded `reader_error` against a genuinely live process AND unfinished reader task — the deterministic proof of the race fix that an E2E cannot force reliably.
- E2E: `oversized_frame_from_backend_is_contained_e2e` (Ready-window garbage frame → that venv evicted, sibling venv keeps serving) and `zombie_reader_during_creating_is_not_pooled_e2e` (Creating-window garbage frame with the process left alive → contained creation failure, not a pooled zombie; without the fix this hung in 15/20 stress runs, with it 0/20).
- All detection-power verified via throwaway breaks; `make all` + full suite run twice per round, no flakes.

Review notes: independently reviewed and externally reviewed pre-push across three rounds (round 1: changes-requested — the Creating-window zombie; round 2: changes-requested — the consumed-before-finish ordering; round 3: approve). Two non-blocking round-1 items (lighter boundary test, header-block comment accuracy) and a round-3 wording nit were folded in.

Closes #106