### PR TITLE
feat: make the pool sweep interval configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,12 +212,13 @@ Settings priority: **CLI flag > environment variable > config file > default**
 | `TYPEMUX_CC_BACKEND` | LSP backend to use | `pyright` |
 | `TYPEMUX_CC_MAX_BACKENDS` | Max concurrent backend processes | `8` |
 | `TYPEMUX_CC_BACKEND_TTL` | Backend TTL in seconds (0 = disabled) | `1800` |
+| `TYPEMUX_CC_POOL_SWEEP_INTERVAL` | Interval in seconds between pool sweep ticks (drives both TTL eviction and the venv staleness sweep; must be > 0) | `60` |
 | `TYPEMUX_CC_FANOUT_TIMEOUT` | Fan-out timeout in seconds for `workspace/symbol` (0 = no timeout) | `5` |
 | `TYPEMUX_CC_VENV_CHECK_INTERVAL` | Interval in seconds between venv identity checks (0 = disable venv identity tracking) | `5` |
 | `TYPEMUX_CC_INIT_HANDSHAKE_TIMEOUT` | Backend spawn → `initialize` handshake timeout in seconds | `10` |
 | `RUST_LOG` | Log level | `typemux_cc=debug` |
 
-An invalid value for a numeric variable above (e.g. `TYPEMUX_CC_FANOUT_TIMEOUT=5s`) fails startup with an explicit error instead of silently falling back to the default.
+An invalid value for a numeric variable above (e.g. `TYPEMUX_CC_FANOUT_TIMEOUT=5s`) fails startup with an explicit error instead of silently falling back to the default. `TYPEMUX_CC_POOL_SWEEP_INTERVAL=0` also fails startup — unlike the other vars, `0` isn't a valid "disable" sentinel here; use `--backend-ttl 0` / `TYPEMUX_CC_VENV_CHECK_INTERVAL=0` to disable the sweep's individual jobs instead.
 
 ## Typical Use Case
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -286,8 +286,8 @@ Checks are debounced to once per `TYPEMUX_CC_VENV_CHECK_INTERVAL` seconds
 (default 5; `0` disables tracking; a non-integer value fails startup with an
 explicit error). Triggers: `ensure_backend_in_pool`
 (all venv-checked request methods), `didOpen`/`didChange` forwarding, and a
-60s background sweep (shared with the TTL timer, armed even when TTL is
-disabled).
+background sweep on the `TYPEMUX_CC_POOL_SWEEP_INTERVAL` tick (default 60s;
+shared with the TTL timer, armed even when TTL is disabled).
 
 | Observation | Behavior |
 |-------------|----------|
@@ -298,7 +298,8 @@ disabled).
 | `pyvenv.cfg` missing ≥ grace | Evict without respawn; reset affected documents' cached venv so the next request re-resolves it — usually the strict-mode ".venv not found" error |
 
 The background sweep evicts without respawning (the next request lazily
-respawns), so an idle stale backend is corrected within ~60s even if no
+respawns), so an idle stale backend is corrected within one sweep interval
+(default ~60s, configurable via `TYPEMUX_CC_POOL_SWEEP_INTERVAL`) even if no
 request ever targets it again.
 
 Staleness eviction reuses the standard eviction path, so the session-id
@@ -642,7 +643,7 @@ The main event loop in `proxy/mod.rs` uses `tokio::select!` with 7 arms, unbiase
 │ Client reader     │ mpsc channel (dedicated reader task)   │
 │ Backend reader    │ mpsc channel (all backends)            │
 │ Creation outcome  │ mpsc channel (backend-creation tasks)  │
-│ TTL timer         │ 60s interval sweep                     │
+│ TTL timer         │ sweep tick (default 60s, configurable) │
 │ Warmup timer      │ nearest warmup deadline                │
 │ Fan-out timer     │ nearest fan-out deadline                │
 │ Replay queue      │ one Creating-queued message/iteration  │

--- a/src/backend_pool.rs
+++ b/src/backend_pool.rs
@@ -96,12 +96,32 @@ pub fn init_handshake_timeout() -> Duration {
         .map_or(DEFAULT_INIT_HANDSHAKE_TIMEOUT, Duration::from_secs)
 }
 
-/// Env vars validated by `validate_env_config`, backing the four accessors above.
-const TIMEOUT_ENV_VARS: [&str; 4] = [
+/// Default pool sweep tick interval; overridable via
+/// `TYPEMUX_CC_POOL_SWEEP_INTERVAL` env var. Drives both periodic jobs in the
+/// event loop: TTL eviction and the venv staleness sweep.
+const DEFAULT_POOL_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Returns the pool sweep tick interval. Unlike the four accessors above,
+/// `0` is not a valid value here (it would silently disable both the TTL
+/// sweep and the venv staleness sweep) — `validate_env_config` rejects it at
+/// startup, so this is only reachable with an unset or already-validated
+/// (positive) value on the normal startup path. (`--doctor` skips that
+/// validation and calls this directly; it reports raw invalid values itself
+/// instead of relying on this fallback.)
+pub fn pool_sweep_interval() -> Duration {
+    std::env::var("TYPEMUX_CC_POOL_SWEEP_INTERVAL")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map_or(DEFAULT_POOL_SWEEP_INTERVAL, Duration::from_secs)
+}
+
+/// Env vars validated by `validate_env_config`, backing the five accessors above.
+const TIMEOUT_ENV_VARS: [&str; 5] = [
     "TYPEMUX_CC_WARMUP_TIMEOUT",
     "TYPEMUX_CC_FANOUT_TIMEOUT",
     "TYPEMUX_CC_VENV_CHECK_INTERVAL",
     "TYPEMUX_CC_INIT_HANDSHAKE_TIMEOUT",
+    "TYPEMUX_CC_POOL_SWEEP_INTERVAL",
 ];
 
 /// Validates the timeout/interval env vars above at startup, before the event
@@ -110,13 +130,27 @@ const TIMEOUT_ENV_VARS: [&str; 4] = [
 /// returns an error naming the variable and its raw value instead of letting
 /// the accessors swallow it via `.ok()`. Not called for `--doctor`, which
 /// reports invalid values instead of aborting.
+///
+/// `TYPEMUX_CC_POOL_SWEEP_INTERVAL` additionally rejects `0`: unlike the
+/// other four vars (where `0` is a documented "disable" sentinel), `0` here
+/// would silently disable both periodic jobs it drives. Disabling TTL
+/// eviction is already expressed via `--backend-ttl 0`, and disabling the
+/// venv staleness sweep via `TYPEMUX_CC_VENV_CHECK_INTERVAL=0`.
 pub fn validate_env_config() -> Result<(), String> {
     for env_var in TIMEOUT_ENV_VARS {
         if let Ok(raw) = std::env::var(env_var) {
-            if raw.parse::<u64>().is_err() {
-                return Err(format!(
-                    "invalid {env_var}={raw:?}: expected a non-negative integer number of seconds"
-                ));
+            match raw.parse::<u64>() {
+                Err(_) => {
+                    return Err(format!(
+                        "invalid {env_var}={raw:?}: expected a non-negative integer number of seconds"
+                    ));
+                }
+                Ok(0) if env_var == "TYPEMUX_CC_POOL_SWEEP_INTERVAL" => {
+                    return Err(format!(
+                        "invalid {env_var}={raw:?}: must be a positive integer number of seconds (use --backend-ttl 0 or TYPEMUX_CC_VENV_CHECK_INTERVAL=0 to disable the sweep's individual jobs instead)"
+                    ));
+                }
+                Ok(_) => {}
             }
         }
     }

--- a/src/backend_pool.rs
+++ b/src/backend_pool.rs
@@ -132,7 +132,7 @@ const TIMEOUT_ENV_VARS: [&str; 5] = [
 /// reports invalid values instead of aborting.
 ///
 /// `TYPEMUX_CC_POOL_SWEEP_INTERVAL` additionally rejects `0`: unlike the
-/// other four vars (where `0` is a documented "disable" sentinel), `0` here
+/// other four vars (which accept `0` with variable-specific semantics), `0` here
 /// would silently disable both periodic jobs it drives. Disabling TTL
 /// eviction is already expressed via `--backend-ttl 0`, and disabling the
 /// venv staleness sweep via `TYPEMUX_CC_VENV_CHECK_INTERVAL=0`.

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -105,11 +105,16 @@ fn env_only_source(env_var: &str, config_report: &ConfigLoadReport) -> String {
 /// (see `main.rs`), so an invalid value never aborts here; instead this shows
 /// the raw value and marks it invalid rather than reporting the accessor's
 /// silent default fallback as if it were in effect.
+///
+/// `is_valid` covers value-level rules beyond parseability (e.g.
+/// `pool_sweep_interval`'s rejection of `0`); the other callers pass `|_|
+/// true` since parseability is their only constraint.
 fn timeout_env_item(
     name: &str,
     env_var: &str,
     effective: std::time::Duration,
     config_report: &ConfigLoadReport,
+    is_valid: impl Fn(u64) -> bool,
 ) -> ConfigItem {
     let raw = std::env::var(env_var);
     let source = env_only_source(env_var, config_report);
@@ -119,7 +124,7 @@ fn timeout_env_item(
             value: effective.as_secs().to_string(),
             source,
         },
-        Ok(raw) if raw.parse::<u64>().is_ok() => ConfigItem {
+        Ok(raw) if raw.parse::<u64>().is_ok_and(is_valid) => ConfigItem {
             name: name.to_string(),
             value: effective.as_secs().to_string(),
             source,
@@ -246,6 +251,7 @@ pub async fn collect_doctor_report(
         "TYPEMUX_CC_WARMUP_TIMEOUT",
         backend_pool::warmup_timeout(),
         config_report,
+        |_| true,
     );
 
     let fanout_timeout_item = timeout_env_item(
@@ -253,6 +259,7 @@ pub async fn collect_doctor_report(
         "TYPEMUX_CC_FANOUT_TIMEOUT",
         backend_pool::fanout_timeout(),
         config_report,
+        |_| true,
     );
 
     let venv_check_interval_item = timeout_env_item(
@@ -260,6 +267,7 @@ pub async fn collect_doctor_report(
         "TYPEMUX_CC_VENV_CHECK_INTERVAL",
         backend_pool::venv_check_interval(),
         config_report,
+        |_| true,
     );
 
     let init_handshake_timeout_item = timeout_env_item(
@@ -267,6 +275,17 @@ pub async fn collect_doctor_report(
         "TYPEMUX_CC_INIT_HANDSHAKE_TIMEOUT",
         backend_pool::init_handshake_timeout(),
         config_report,
+        |_| true,
+    );
+
+    // `0` is invalid for this one (see `validate_env_config`'s doc comment):
+    // it would silently disable both periodic jobs the sweep tick drives.
+    let pool_sweep_interval_item = timeout_env_item(
+        "pool_sweep_interval",
+        "TYPEMUX_CC_POOL_SWEEP_INTERVAL",
+        backend_pool::pool_sweep_interval(),
+        config_report,
+        |v| v > 0,
     );
 
     let log_file_value: String = matches
@@ -294,6 +313,7 @@ pub async fn collect_doctor_report(
             fanout_timeout_item,
             venv_check_interval_item,
             init_handshake_timeout_item,
+            pool_sweep_interval_item,
             log_file_item,
         ],
     };

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -344,11 +344,11 @@ impl LspProxy {
         // `pool_sweep_interval()` (default 60s, configurable via
         // `TYPEMUX_CC_POOL_SWEEP_INTERVAL`).
         let sweep_interval = crate::backend_pool::pool_sweep_interval();
-        let mut ttl_interval = tokio::time::interval(sweep_interval);
-        ttl_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let mut sweep_interval = tokio::time::interval(sweep_interval);
+        sweep_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         // Consume the first immediate tick so the first real tick fires after
         // one full sweep_interval.
-        ttl_interval.tick().await;
+        sweep_interval.tick().await;
 
         loop {
             // Compute deadlines before entering select! to avoid borrow conflicts
@@ -402,7 +402,7 @@ impl LspProxy {
                 // TTL-based auto-eviction and venv-identity staleness sweep.
                 // Always armed (not gated on backend_ttl) so the staleness
                 // sweep runs even when TTL eviction is disabled.
-                _ = ttl_interval.tick() => {
+                _ = sweep_interval.tick() => {
                     if self.backend_ttl.is_some() {
                         self.evict_expired_backends(&mut client_writer).await?;
                     }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -340,10 +340,14 @@ impl LspProxy {
 
         let mut didopen_count: usize = 0;
 
-        // TTL sweep timer: checks every 60 seconds for expired backends
-        let mut ttl_interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        // TTL sweep timer: checks for expired backends every
+        // `pool_sweep_interval()` (default 60s, configurable via
+        // `TYPEMUX_CC_POOL_SWEEP_INTERVAL`).
+        let sweep_interval = crate::backend_pool::pool_sweep_interval();
+        let mut ttl_interval = tokio::time::interval(sweep_interval);
         ttl_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        // Consume the first immediate tick so the first real tick fires after 60s
+        // Consume the first immediate tick so the first real tick fires after
+        // one full sweep_interval.
         ttl_interval.tick().await;
 
         loop {

--- a/tests/env_config_test.rs
+++ b/tests/env_config_test.rs
@@ -60,7 +60,7 @@ fn invalid_pool_sweep_interval_fails_startup() {
     );
 }
 
-/// Unlike the other three vars, `0` is a value-level error here, not just an
+/// Unlike the other four vars, `0` is a value-level error here, not just an
 /// unparseable one: it would silently disable both the TTL sweep and the
 /// venv staleness sweep (issue #126).
 #[test]

--- a/tests/env_config_test.rs
+++ b/tests/env_config_test.rs
@@ -50,6 +50,31 @@ fn invalid_init_handshake_timeout_fails_startup() {
 }
 
 #[test]
+fn invalid_pool_sweep_interval_fails_startup() {
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.env("TYPEMUX_CC_POOL_SWEEP_INTERVAL", "abc");
+
+    cmd.assert().failure().stderr(
+        predicate::str::contains("TYPEMUX_CC_POOL_SWEEP_INTERVAL")
+            .and(predicate::str::contains("abc")),
+    );
+}
+
+/// Unlike the other three vars, `0` is a value-level error here, not just an
+/// unparseable one: it would silently disable both the TTL sweep and the
+/// venv staleness sweep (issue #126).
+#[test]
+fn zero_pool_sweep_interval_fails_startup() {
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.env("TYPEMUX_CC_POOL_SWEEP_INTERVAL", "0");
+
+    cmd.assert().failure().stderr(
+        predicate::str::contains("TYPEMUX_CC_POOL_SWEEP_INTERVAL")
+            .and(predicate::str::contains("0")),
+    );
+}
+
+#[test]
 fn doctor_reports_invalid_env_value_distinctly() {
     let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
     cmd.arg("--doctor").env("TYPEMUX_CC_WARMUP_TIMEOUT", "abc");
@@ -99,6 +124,55 @@ fn doctor_distinguishes_default_valid_and_invalid_env_values() {
     let invalid_item = find_config_item(&invalid_json, "fanout_timeout");
     assert!(invalid_item["source"].as_str().unwrap().contains("invalid"));
     assert!(invalid_item["value"].as_str().unwrap().contains("5s"));
+}
+
+#[test]
+fn doctor_distinguishes_default_valid_and_invalid_pool_sweep_interval() {
+    // default: unset
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.arg("--doctor").arg("--json");
+    let default_output = cmd.output().expect("failed to run");
+    assert!(default_output.status.success());
+    let default_json: serde_json::Value = serde_json::from_slice(&default_output.stdout).unwrap();
+    let default_item = find_config_item(&default_json, "pool_sweep_interval");
+    assert_eq!(default_item["source"], "default");
+    assert_eq!(default_item["value"], "60");
+
+    // valid env value
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.arg("--doctor")
+        .arg("--json")
+        .env("TYPEMUX_CC_POOL_SWEEP_INTERVAL", "5");
+    let valid_output = cmd.output().expect("failed to run");
+    assert!(valid_output.status.success());
+    let valid_json: serde_json::Value = serde_json::from_slice(&valid_output.stdout).unwrap();
+    let valid_item = find_config_item(&valid_json, "pool_sweep_interval");
+    assert_eq!(valid_item["source"], "env: TYPEMUX_CC_POOL_SWEEP_INTERVAL");
+    assert_eq!(valid_item["value"], "5");
+
+    // invalid: unparseable
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.arg("--doctor")
+        .arg("--json")
+        .env("TYPEMUX_CC_POOL_SWEEP_INTERVAL", "5s");
+    let invalid_output = cmd.output().expect("failed to run");
+    assert!(invalid_output.status.success());
+    let invalid_json: serde_json::Value = serde_json::from_slice(&invalid_output.stdout).unwrap();
+    let invalid_item = find_config_item(&invalid_json, "pool_sweep_interval");
+    assert!(invalid_item["source"].as_str().unwrap().contains("invalid"));
+    assert!(invalid_item["value"].as_str().unwrap().contains("5s"));
+
+    // invalid: parseable but zero (value-level rule, not just parseability)
+    let mut cmd = Command::cargo_bin("typemux-cc").unwrap();
+    cmd.arg("--doctor")
+        .arg("--json")
+        .env("TYPEMUX_CC_POOL_SWEEP_INTERVAL", "0");
+    let zero_output = cmd.output().expect("failed to run");
+    assert!(zero_output.status.success());
+    let zero_json: serde_json::Value = serde_json::from_slice(&zero_output.stdout).unwrap();
+    let zero_item = find_config_item(&zero_json, "pool_sweep_interval");
+    assert!(zero_item["source"].as_str().unwrap().contains("invalid"));
+    assert!(zero_item["value"].as_str().unwrap().contains('0'));
 }
 
 fn find_config_item<'a>(report: &'a serde_json::Value, name: &str) -> &'a serde_json::Value {

--- a/tests/ttl_eviction_test.rs
+++ b/tests/ttl_eviction_test.rs
@@ -1,0 +1,150 @@
+mod support;
+
+use support::{PackageConfig, ProxyUnderTest, WorkspaceConfig};
+
+/// E2E: TTL eviction of an idle backend, observable in test time (issue
+/// #126). Before the pool sweep tick was configurable, TTL eviction only
+/// ran on a hardcoded 60s tick, making this untestable within a reasonable
+/// wall-clock budget (#97, #124). `TYPEMUX_CC_POOL_SWEEP_INTERVAL=1` +
+/// `TYPEMUX_CC_BACKEND_TTL=1` bring both down to 1s.
+///
+/// Eviction is observed two ways: the empty `publishDiagnostics` the proxy
+/// sends for the evicted venv's open document (`wait_for_crash_cleanup`
+/// reuses the same signal crash recovery uses), and — the stronger proof —
+/// a second hover for the same file must go through a brand-new backend
+/// lifetime (its own `initialize`/`didOpen` handshake), which only happens
+/// if the first backend was actually evicted from the pool.
+///
+/// This is a proof-of-purpose test for the pool-sweep-interval knob, not
+/// the full #97 TTL matrix (pending-request skip, etc.) — that's a
+/// follow-up PR now that this is E2E-testable at all.
+#[tokio::test]
+async fn idle_backend_evicted_after_ttl_expiry() {
+    let scenario_life1 = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            // dispatch_initialized forwards a 2nd "initialized" to fallback backends
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover life1" } } }]
+            }
+        ]
+    });
+
+    let config = WorkspaceConfig {
+        packages: vec![PackageConfig {
+            name: "pkg".to_string(),
+            scenario: scenario_life1,
+            has_venv: true,
+        }],
+    };
+
+    let (temp_dir, root) = support::setup_test_workspace(&config);
+    let pkg_dir = root.join("pkg");
+    let mut proxy = ProxyUnderTest::spawn_with_env(
+        temp_dir,
+        root.clone(),
+        &pkg_dir,
+        &[
+            ("TYPEMUX_CC_POOL_SWEEP_INTERVAL", "1"),
+            ("TYPEMUX_CC_BACKEND_TTL", "1"),
+        ],
+    );
+
+    let root_uri = support::path_to_uri(&pkg_dir);
+    let init_resp = proxy.initialize(&root_uri).await;
+    assert!(
+        init_resp.error.is_none(),
+        "initialize should not return an error"
+    );
+    proxy.send_initialized().await;
+
+    let file_a = pkg_dir.join("a.py");
+    std::fs::write(&file_a, "a = 1\n").unwrap();
+    let file_a_uri = support::path_to_uri(&file_a);
+    proxy.did_open(&file_a_uri, "a = 1\n").await;
+
+    let hover_params = serde_json::json!({
+        "textDocument": { "uri": &file_a_uri },
+        "position": { "line": 0, "character": 0 }
+    });
+
+    // Establishes doc.venv (so eviction later clears its diagnostics) and
+    // sets last_used, the TTL clock's starting point.
+    let hover1 = proxy
+        .request("textDocument/hover", hover_params.clone())
+        .await;
+    assert!(
+        hover1.error.is_none(),
+        "hover before eviction should succeed, got error: {:?}",
+        hover1.error
+    );
+    assert_eq!(
+        hover1.result.as_ref().unwrap()["contents"]["value"],
+        "hover life1"
+    );
+
+    // Idle from here: no further requests until the sweep evicts. Worst
+    // case is ~1 sweep interval (1s) plus the 1s TTL itself; 8s is a
+    // generous margin over that for CI jitter, while staying far below the
+    // old hardcoded 60s tick.
+    let notifications = proxy.wait_for_crash_cleanup(1, 8000).await;
+    let diag_count = notifications
+        .iter()
+        .filter(|m| m.method.as_deref() == Some("textDocument/publishDiagnostics"))
+        .count();
+    assert!(
+        diag_count >= 1,
+        "expected at least 1 publishDiagnostics clearing a.py, got {diag_count}"
+    );
+
+    // Second lifetime: a lazy respawn on the next request restores a.py
+    // (should_restore_document) and re-runs the initialize handshake. A
+    // spurious extra respawn, or no eviction at all, would desync this
+    // scenario's steps and fail the hover below.
+    let scenario_life2 = serde_json::json!({
+        "on_startup": [],
+        "steps": [
+            {
+                "expect": { "method": "initialize" },
+                "actions": [{ "type": "respond", "body": { "capabilities": { "hoverProvider": true } } }]
+            },
+            { "expect": { "method": "initialized" }, "actions": [] },
+            { "expect": { "method": "textDocument/didOpen" }, "actions": [] },
+            {
+                "expect": { "method": "textDocument/hover" },
+                "actions": [{ "type": "respond", "body": { "contents": { "kind": "plaintext", "value": "hover life2" } } }]
+            },
+            {
+                "expect": { "method": "shutdown" },
+                "actions": [{ "type": "respond", "body": null }]
+            }
+        ]
+    });
+    support::write_venv_fixture(&pkg_dir, &scenario_life2);
+
+    let hover2 = proxy.request("textDocument/hover", hover_params).await;
+    assert!(
+        hover2.error.is_none(),
+        "hover after TTL eviction should succeed against a respawned backend, got error: {:?}",
+        hover2.error
+    );
+    assert_eq!(
+        hover2.result.as_ref().unwrap()["contents"]["value"],
+        "hover life2",
+        "hover response must come from the respawned (life2) backend, proving the life1 backend was evicted"
+    );
+
+    let shutdown_resp = proxy.shutdown_and_exit().await;
+    assert!(
+        shutdown_resp.error.is_none(),
+        "shutdown should not return an error"
+    );
+}


### PR DESCRIPTION
## Summary

The pool sweep timer — the tick driving BOTH periodic jobs (TTL eviction and the venv identity staleness sweep) — was hardcoded to 60 seconds. The TTL value itself was already configurable, but even `TTL=1s` only took effect on the next 60s tick, making TTL eviction untestable in reasonable wall-clock time (#97's two remaining checkboxes were deliberately skipped in #124 for exactly this reason).

## Changes

- New `TYPEMUX_CC_POOL_SWEEP_INTERVAL` (seconds, default 60), following the existing timeout-var pattern: accessor in `backend_pool.rs`, membership in `TIMEOUT_ENV_VARS` (startup validation via `validate_env_config()`, #102), and `--doctor` reporting.
- `0` is rejected at startup — deliberately asymmetric with the other four timeout vars (which accept `0` with variable-specific semantics): `0` here would silently kill both periodic jobs, and disabling them is already expressed via `--backend-ttl 0` and `TYPEMUX_CC_VENV_CHECK_INTERVAL=0`. `--doctor` grew a value-level validity predicate so it reports `0` as invalid consistently with startup.
- The event-loop tick variable was renamed `ttl_interval` → `sweep_interval` (it drives more than TTL), and README/ARCHITECTURE no longer assert a fixed 60s.
- No behavior change at the default.

## Tests

- `tests/env_config_test.rs`: invalid value fails startup; `0` fails startup; `--doctor` distinguishes default / valid / unparseable / zero (4 states).
- New `tests/ttl_eviction_test.rs::idle_backend_evicted_after_ttl_expiry`: with `TYPEMUX_CC_POOL_SWEEP_INTERVAL=1` + `TYPEMUX_CC_BACKEND_TTL=1`, an idle backend is observably evicted in ~2.5s — proven both by the eviction's diagnostics-clear signal and by a subsequent request requiring a full fresh backend lifetime. Detection power verified: hardcoding 60s back makes the test fail by timeout.
- This unblocks #97's remaining TTL checkboxes (follow-up test PR).
- `make all` + full suite twice, clean. Externally reviewed pre-push (verdict: approve; three non-blocking comment/naming nits folded into a follow-up commit).

Closes #126
Refs #97