### PR TITLE
fix: canonicalize the restoration fallback path comparison

### DIFF
--- a/src/proxy/initialization.rs
+++ b/src/proxy/initialization.rs
@@ -72,7 +72,15 @@ pub(crate) fn should_restore_document(
     doc_venv == Some(venv)
         || (doc_venv.is_none()
             && match (file_path, venv_parent) {
-                (Some(fp), Some(vp)) => fp.starts_with(vp),
+                (Some(fp), Some(vp)) => {
+                    // `fp` is the raw client URI's path (logical form); `vp`
+                    // is always canonical, derived from `venv`, which has
+                    // been canonical since #116. Canonicalize `fp` too,
+                    // mirroring `find_venv`'s entry-point idiom, or a
+                    // symlinked project path never matches here (#119).
+                    let fp = fp.canonicalize().unwrap_or_else(|_| fp.to_path_buf());
+                    fp.starts_with(vp)
+                }
                 _ => false,
             })
 }
@@ -408,6 +416,36 @@ mod tests {
             Path::new(VENV),
             Some(Path::new("/repo/a.py")),
             None,
+        ));
+    }
+
+    /// Regression test for #119: the file path arrives in logical
+    /// (symlinked) form from the client URI, while `venv`/`venv_parent` are
+    /// always canonical (physical) form since #116 — mirroring the #95
+    /// scenario `find_venv` already handles (e.g. macOS's `/tmp` ->
+    /// `/private/tmp`). Without canonicalizing `file_path` in the fallback
+    /// comparison, `starts_with` can never match here.
+    #[test]
+    fn restores_unresolved_document_reached_through_a_symlinked_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+
+        let real_project = root.join("real_project");
+        std::fs::create_dir(&real_project).unwrap();
+        let file = real_project.join("a.py");
+        std::fs::write(&file, "a = 1\n").unwrap();
+
+        let symlink_project = root.join("symlinked_project");
+        std::os::unix::fs::symlink(&real_project, &symlink_project).unwrap();
+        let file_via_symlink = symlink_project.join("a.py");
+
+        let venv = real_project.join(".venv");
+
+        assert!(should_restore_document(
+            None,
+            &venv,
+            Some(&file_via_symlink),
+            Some(&real_project),
         ));
     }
 

--- a/src/proxy/initialization.rs
+++ b/src/proxy/initialization.rs
@@ -75,11 +75,26 @@ pub(crate) fn should_restore_document(
                 (Some(fp), Some(vp)) => {
                     // `fp` is the raw client URI's path (logical form); `vp`
                     // is always canonical, derived from `venv`, which has
-                    // been canonical since #116. Canonicalize `fp` too,
-                    // mirroring `find_venv`'s entry-point idiom, or a
-                    // symlinked project path never matches here (#119).
-                    let fp = fp.canonicalize().unwrap_or_else(|_| fp.to_path_buf());
-                    fp.starts_with(vp)
+                    // been canonical since #116. Canonicalize `fp`'s PARENT
+                    // directory, not `fp` itself, and compare that against
+                    // `vp` — mirroring `find_venv`'s entry-point idiom
+                    // (which also canonicalizes only the parent). `didOpen`
+                    // genuinely delivers unsaved buffers: canonicalizing the
+                    // full path would fail for a file that doesn't exist on
+                    // disk yet even though its parent directory does, and
+                    // silently fall back to the uncanonicalized path, so a
+                    // symlinked project would still never match for that
+                    // case (#119). Only containment matters here, so the
+                    // parent-only comparison is sufficient.
+                    fp.parent().map_or_else(
+                        || fp.starts_with(vp),
+                        |parent| {
+                            let canonical_parent = parent
+                                .canonicalize()
+                                .unwrap_or_else(|_| parent.to_path_buf());
+                            canonical_parent.starts_with(vp)
+                        },
+                    )
                 }
                 _ => false,
             })
@@ -445,6 +460,36 @@ mod tests {
             None,
             &venv,
             Some(&file_via_symlink),
+            Some(&real_project),
+        ));
+    }
+
+    /// Regression test for #119 (parent-canonicalize follow-up): `didOpen`
+    /// genuinely delivers unsaved buffers — the target file itself may not
+    /// exist on disk yet even though its parent directory does. Only the
+    /// project directory is created here; `new_file.py` is deliberately
+    /// never written. A whole-path `canonicalize()` fails for a
+    /// not-yet-existing file and falls back to the raw (symlinked) path, so
+    /// this case still missed restoration even after the first #119 fix —
+    /// canonicalizing the parent directory instead closes it.
+    #[test]
+    fn restores_unresolved_document_for_an_unsaved_file_under_a_symlinked_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+
+        let real_project = root.join("real_project");
+        std::fs::create_dir(&real_project).unwrap();
+
+        let symlink_project = root.join("symlinked_project");
+        std::os::unix::fs::symlink(&real_project, &symlink_project).unwrap();
+        let unsaved_file_via_symlink = symlink_project.join("new_file.py");
+
+        let venv = real_project.join(".venv");
+
+        assert!(should_restore_document(
+            None,
+            &venv,
+            Some(&unsaved_file_via_symlink),
             Some(&real_project),
         ));
     }


### PR DESCRIPTION
## Summary

#116 canonicalized venv resolution end to end — pool keys and `doc.venv` are always in canonical (physical) form — but the document-restoration fallback still compared a RAW client path against them: `should_restore_document`'s `doc.venv == None` branch did `file_path.starts_with(venv_parent)` with a logical path on the left and a canonical one on the right. Under a symlinked project path (the #95 scenario, e.g. macOS `/tmp` → `/private/tmp`), that comparison could never match, so a document whose venv was never resolved at `didOpen` silently missed the restoration sweep. Fail-closed and narrow (flagged as a known follow-up in #116's description), but wrong.

## Changes

`src/proxy/initialization.rs`, the guarded fallback arm only: canonicalize the file's PARENT directory and compare that against `venv_parent`. Two review-driven properties:
- Parent, not the whole path (external review catch): `didOpen` legitimately delivers unsaved/new buffers whose file doesn't exist on disk yet — whole-path `canonicalize()` fails for those and falls back to the logical path, leaving the same bug for that subcase. The parent directory exists and canonicalizes; this mirrors what `find_venv` itself does.
- The canonicalization lives inside the `doc.venv == None` arm, so documents with a resolved venv (the #118 ownership guarantee path) never pay the syscall and are structurally untouched.

## Tests

Two new unit tests alongside the existing #118 suite (real tempdirs + `std::os::unix::fs::symlink`, since canonicalize needs real filesystem entries):
- `restores_unresolved_document_reached_through_a_symlinked_path` (file exists)
- `restores_unresolved_document_for_an_unsaved_file_under_a_symlinked_path` (file deliberately never created)

Detection power verified with the exact discrimination the review asked for: reverting to whole-path canonicalize fails only the unsaved-file test; reverting the fix entirely fails both symlink tests; the #118 ownership tests pass in every configuration. E2E deliberately omitted: the existing symlink fixture warns of nondeterministic didOpen ordering across two restored documents, and a flaky E2E is worse than none — the non-symlink respawn wiring is already covered by `none_venv_document_still_restores_on_respawn`.

`make all` + full suite twice, clean. Independently and externally reviewed pre-push across two rounds (round 1: changes-requested — the unsaved-buffer case; round 2: approve).

Closes #119