### PR TITLE
docs: document frozen empty-capabilities fallback as verified safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ npm install -g pyright
 - **🔄 Multi-project venv switching (monorepos)** — typemux-cc keeps a per-`.venv` backend pool and routes requests to the correct one. Switching between projects is instant.
 - **🔀 Multi-backend support** — Not locked into pyright. Choose between pyright, ty, or pyrefly — switch via a single env var.
 
+> **Frozen capabilities on cold start** — When no `.venv` exists at startup, `initialize` answers with empty capabilities and that advertisement stays frozen for the session — verified with Claude Code 2.1.207 that the client keeps sending LSP requests regardless, so nothing is gated (see [Frozen Empty Capabilities](docs/ARCHITECTURE.md#frozen-empty-capabilities-important)).
+
 > **Why LSP over text search?** In monorepos, grep returns false positives from same-named types across projects. LSP resolves references at the type-system level. See [real-world benchmarks](./docs/why-lsp.md).
 
 ## Supported Backends

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -267,6 +267,22 @@ Two distinct caches can go stale, and they fail differently:
    identity tracking (below), a backend would keep serving after its `.venv`
    was replaced or deleted — the "silently lying LSP" failure mode.
 
+### Frozen Empty Capabilities (Important)
+
+The `capabilities: {}` response above is static and never updated: there is
+no `registerCapability` call anywhere in the codebase, so once `initialize`
+answers with an empty object, the client sees that same advertisement for
+the rest of the session — even after a `.venv` is created later and a real
+backend spawns via the pool-miss path. This is safe in practice: verified
+empirically with Claude Code 2.1.207 on 2026-07-12 that the client does not
+gate LSP requests on advertised capabilities. `textDocument/hover`,
+`textDocument/documentSymbol`, `textDocument/definition` (cross-file),
+`textDocument/references`, and `textDocument/publishDiagnostics` all
+worked immediately after mid-session venv discovery created the backend,
+with no re-advertisement and no client restart. The frozen `{}` response is
+therefore a deliberate trade-off, not a functional gap for the tested
+Claude Code version.
+
 ## Venv Identity Tracking
 
 ### Problem


### PR DESCRIPTION
## Summary

Resolves the verification question in #105: does Claude Code gate LSP features on the frozen empty-capabilities `initialize` response? Empirical answer (Claude Code 2.1.207, typemux-cc 0.2.17, pyright 1.1.411, 2026-07-12): no — the client sends all requests regardless of the advertised capabilities, and every verified feature works once a `.venv` appears mid-session. This PR documents the behavior as a deliberate, verified trade-off.

## Changes

- `README.md` — standalone note below "Problems Solved": cold-start empty capabilities stay frozen for the session; verified with Claude Code 2.1.207 that nothing is gated; links to the new ARCHITECTURE subsection.
- `docs/ARCHITECTURE.md` — new "Frozen Empty Capabilities (Important)" subsection under Strict Venv Mode: static `{}` advertisement, no `registerCapability`, verification result (`textDocument/hover`, `textDocument/documentSymbol`, cross-file `textDocument/definition`, `textDocument/references`, `textDocument/publishDiagnostics` all worked after mid-session venv discovery), conclusion scoped to the tested client version.

## Tests

- `make all` (fmt + clippy `-D warnings` + full test suite) — docs-only change.

## Review

Two-round external review (codex): R1 changes-requested — scope harmlessness claims to the verified client version, shorten the README bullet, code-format method names; all applied. R2 approve, with one non-blocking wording fix ("When no `.venv` exists at startup…") also applied.

The separate Claude Code client hang on the venv-present startup path is intentionally out of scope here — tracked in #140.

Closes #105