### PR TITLE
chore: bump version to 0.2.18

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "typemux-cc",
       "source": "./",
       "description": "Python type-checker LSP multiplexer for Claude Code (pyright, ty, pyrefly)",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "homepage": "https://github.com/K-dash/typemux-cc",
       "repository": "https://github.com/K-dash/typemux-cc",
       "strict": false

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typemux-cc",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "Python type-checker LSP multiplexer for Claude Code (pyright, ty, pyrefly)",
   "author": {
     "name": "K-dash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "typemux-cc"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typemux-cc"
-version = "0.2.17"
+version = "0.2.18"
 edition = "2021"
 rust-version = "1.88"
 


### PR DESCRIPTION
## Summary

Release v0.2.18.

Merging this PR auto-creates the `v0.2.18` tag (#132), which triggers the release build for all three targets.

## Since v0.2.17

- #142 — mitigate #140: answer `initialize` instantly with empty capabilities and create the first backend lazily. Removes the permanent "server is starting" LSP wedge on Claude Code 2.1.207 and 2.1.211 for repos with a root `.venv`, verified end-to-end against a real 2.1.211 client.
- #141 — docs: frozen empty-capabilities fallback verified safe (#105).
- #139 — test: cover the pending-request TTL eviction skips end to end.
- #138 — fix: canonicalize the restoration fallback path comparison.
- #137 — fix: answer server-initiated requests that arrive during backend creation.
- #136 — feat: make the pool sweep interval configurable.
- #135 — fix: bound LSP frame and header sizes to contain runaway backends.
- #133 — fix: namespace progress tokens per backend and gate warmup on the indexing token.
- #132 — ci: create release tags automatically when a version bump lands on main.
