### PR TITLE
ci: unbreak zizmor and cargo-deny, and stop upstream ref moves from re-breaking them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           - ubuntu-24.04-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -62,7 +62,7 @@ jobs:
       # step actually failed.
       - name: Upload CI diagnostics
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ci-diagnostics-${{ matrix.os }}
           path: ci-output.log
@@ -77,7 +77,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -97,7 +97,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -114,7 +114,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,19 @@ jobs:
         with:
           persist-credentials: false
 
+      # dtolnay/rust-toolchain publishes via force-pushed branches, not tags,
+      # so the pinned SHA stops being reachable from `stable` every time
+      # upstream pushes (roughly every 3-6 weeks). Both audits below then fire
+      # on a pin that is not actually compromised: `ref-version-mismatch`
+      # because `stable` no longer resolves to it, `impostor-commit` because it
+      # is no longer reachable from any ref. Renovate bumping the digest is
+      # what guards these pins; a review should confirm the new SHA matches the
+      # branch tip at that time.
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable # zizmor: ignore[ref-version-mismatch,impostor-commit]
 
       - name: Cache Rust build
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       # Step timeout (25) is lower than the job timeout (30) on purpose: a
       # step timeout marks the step as failed, so the `if: failure()` upload
@@ -134,8 +142,9 @@ jobs:
       # `master`, not `stable`: passing an explicit `toolchain` input
       # requires `master` per dtolnay/rust-toolchain's own docs (`stable`
       # only carries the "always latest stable" default this input overrides).
+      # The ignored audits are the same two explained in the `ci` job above.
       - name: Setup declared MSRV
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master # zizmor: ignore[ref-version-mismatch,impostor-commit]
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -145,7 +145,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -183,7 +183,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -215,7 +215,7 @@ jobs:
       # the release itself is only ever created once, by `publish`, after
       # every matrix leg here has succeeded.
       - name: Upload build artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.binary_name }}
           path: |
@@ -234,7 +234,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,8 +154,10 @@ jobs:
           TAG: ${{ needs.preflight.outputs.tag }}
         run: ./scripts/check-versions.sh --release "$TAG"
 
+      # See the `ci` job in ci.yml for why these two audits are ignored on
+      # every dtolnay/rust-toolchain pin.
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable # zizmor: ignore[ref-version-mismatch,impostor-commit]
 
       - name: Run quality gate
         run: make ci
@@ -188,7 +190,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable # zizmor: ignore[ref-version-mismatch,impostor-commit]
         with:
           targets: ${{ matrix.target }}
 

--- a/deny.toml
+++ b/deny.toml
@@ -31,7 +31,7 @@ ignore = false
 multiple-versions = "deny"
 wildcards = "deny"
 skip = [
-    { crate = "syn@2", reason = "the ecosystem-wide syn 2 -> 3 migration is in progress: proc-macro crates cross over one release at a time (clap_derive, serde_derive and thiserror-impl already have; tokio-macros, tracing-attributes and the icu4x derives have not), so a 2/3 split is unavoidable for months. A version range rather than an exact pin, because syn 2.x keeps shipping patches while the migration runs. Delete this once nothing pulls syn 2.x." },
+    { crate = "syn@2", reason = "the ecosystem-wide syn 2 -> 3 migration is in progress: proc-macro crates cross over one release at a time (clap_derive, serde_derive and thiserror-impl already have; tokio-macros, tracing-attributes and the icu4x derives have not), so a 2/3 split is unavoidable for months. A version range rather than an exact pin, because syn 2.x keeps shipping patches while the migration runs. Delete this once `cargo tree -i syn@2` comes back empty; until then it stays, and while the graph happens to hold only one syn major it reports an `unnecessary-skip` warning (non-fatal)." },
     { crate = "bitflags@1.3.2", reason = "the only consumer left on bitflags 1.x is lsp-types 0.97 (via fluent-uri); every other dependency in the graph already uses bitflags 2.x. Re-check when lsp-types updates its URI parser." },
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -24,15 +24,14 @@ confidence-threshold = 0.8
 ignore = false
 
 [bans]
-# Only one duplicate exists in the current graph: bitflags 1.3.2 (only via
-# lsp-types -> fluent-uri) vs. 2.10.0 (used by everything else: tokio's
-# parking_lot chain, and dev-dependency tempfile's rustix). Denying
-# duplicates outright with a single, documented skip is more useful than
-# leaving this at "warn" forever: it catches any *new* duplicate immediately
-# instead of silently accumulating more.
+# Duplicates are denied outright, with each tolerated one listed below.
+# Enumerating them is more useful than leaving this at "warn" forever: it
+# catches any *new* duplicate immediately instead of silently accumulating
+# more.
 multiple-versions = "deny"
 wildcards = "deny"
 skip = [
+    { crate = "syn@2", reason = "the ecosystem-wide syn 2 -> 3 migration is in progress: proc-macro crates cross over one release at a time (clap_derive, serde_derive and thiserror-impl already have; tokio-macros, tracing-attributes and the icu4x derives have not), so a 2/3 split is unavoidable for months. A version range rather than an exact pin, because syn 2.x keeps shipping patches while the migration runs. Delete this once nothing pulls syn 2.x." },
     { crate = "bitflags@1.3.2", reason = "the only consumer left on bitflags 1.x is lsp-types 0.97 (via fluent-uri); every other dependency in the graph already uses bitflags 2.x. Re-check when lsp-types updates its URI parser." },
 ]
 


### PR DESCRIPTION
## Summary

Every open Renovate PR (#145–#154) has been failing CI, and so has `main` itself since #143. Neither is a Renovate problem: nothing in this repository changed. Two upstream refs moved, and the version comments next to our pinned SHAs stopped matching them.

`zizmor` was never the variable. `zizmorcore/zizmor-action@192e21d` (v0.5.7) resolves `version: latest` through `support/versions` **inside that pinned action commit**, which maps `latest` to a fixed `ghcr.io/zizmorcore/zizmor` image digest — 1.26.1. Pinning the action SHA already pins the binary, so the audit set has been constant since #121 introduced it on 07-11. What changed was the online audits' input:

| When | Upstream event | Effect on CI |
| --- | --- | --- |
| 07-11 | #121 pins `zizmor-action` v0.5.7 (= zizmor 1.26.1) | green |
| **07-16 16:35** | **dtolnay force-pushes `stable` / `master`** | our pinned SHAs become unreachable from any ref |
| **07-17 19:12** | first failure (#146) | `3 error[impostor-commit]` (high) + `4 warning[ref-version-mismatch]`, all on `dtolnay/rust-toolchain` |
| **07-20 15:10** | **`actions/checkout` v7.0.1 released, moving the `v7` tag** | the `# v7` comments now name a ref that no longer resolves to the pinned v7.0.0 SHA |
| 07-21 onward | symptom changes to `8 medium` | all eight `actions/checkout` pins |
| 07-25 | #144 bumps the `rust-toolchain` digests | incidentally cures the first cause; the eight `checkout` findings remain |

A third, independent failure hit #145 / #150 / #151: `cargo-deny`'s `bans` check, because the ecosystem-wide `syn` 2 → 3 migration puts two majors in the graph at once.

This PR fixes both, and removes the class of breakage rather than just today's instance.

## Changes

**Stop naming moving refs in version comments.** A comment like `# v7` only passes while the pinned SHA happens to be the current tip of a tag that upstream keeps moving — a red window between every upstream release and Renovate's next run (this repo is on `schedule: every weekend`, so up to a week). Exact-version comments name an immutable tag instead.

- `actions/checkout` ×8: bumped to `3d3c42e` and the comment changed `# v7` → `# v7.0.1`.
- `actions/upload-artifact` ×3 and `actions/download-artifact` ×1: SHA unchanged, comment only, `# v7` → `# v7.0.1` and `# v8` → `# v8.0.1`.
- `Swatinem/rust-cache`: `e18b497 # v2` → `c193711 # v2.9.1`. The pinned SHA had no exact tag pointing at it — only the moving `v2`. The two commits differ by `CHANGELOG.md` (+4 −0) and nothing else, so this is inert.

**`dtolnay/rust-toolchain` ×4: suppress two structurally-false-positive audits.** This action publishes via force-pushed branches, not tags, so there is no immutable ref to name. Both audits fire on a pin that is not actually compromised: `ref-version-mismatch` because `stable` no longer resolves to it, `impostor-commit` because the old SHA is no longer reachable from any ref. That is normal for this publisher, not an attack signal. Each of the four pins now carries an inline `# zizmor: ignore[ref-version-mismatch,impostor-commit]`, with the reasoning written out at the first occurrence in `ci.yml` and referenced from the other sites.

Rejected alternative: pinning to the `v1` tag. `v1` was last moved 2025-08-23 while `master` has moved five times since; its `toolchain` input is `required: true`, so the three `# stable` sites would each need an added `with: toolchain: stable`; and its `action.yml` is missing `RUSTUP_PERMIT_COPY_RENAME: 1`. Replacing the action with direct `rustup` calls (which `zizmor`'s `superfluous-actions` suggests at `info` severity, suppressed under this repo's `regular` persona) is a larger change to the release path and belongs in its own PR.

**`deny.toml`: tolerate the `syn` 2/3 split.** Proc-macro crates cross to `syn` 3 one release at a time — `clap_derive`, `serde_derive` and `thiserror-impl` already have; `tokio-macros`, `tracing-attributes` and the icu4x derives have not — so a two-major graph is unavoidable for months and merging the three PRs together does not resolve it. Added a documented `skip` following the existing `bitflags@1.3.2` precedent, rather than downgrading `multiple-versions` to `"warn"` (which that file's own comment rejects).

Two deliberate details: the skip targets `syn@2`, the *older* side, so it becomes a no-op and can be deleted as the migration completes — skipping `syn@3` would leave it needed permanently. And it is a range, not an exact pin like `bitflags@1.3.2`, because `syn` 2.x keeps shipping patches while the migration runs; an exact pin would go stale on the next Renovate lockfile bump.

## Verification

Run with the exact versions CI uses: `zizmor` 1.26.1 (matching the `🌈 zizmor v1.26.1` banner in the failing logs) and `cargo-deny` 0.19.8 (`ENV deny_version` in `cargo-deny-action` v2.0.20's Dockerfile) plus 0.20.2 (bundled by v2.1.1, which #146 upgrades to). `zizmor` was run with a token so the online audits actually execute — without one they are silently skipped and the run is a false green.

Before the fix, the reproduction matched CI exactly: `24 findings (16 suppressed, 8 unsafe fixes): 8 medium`.

Each open PR was merged onto this branch **individually** and both checks run:

| PR | `cargo-deny` 0.19.8 / 0.20.2 | `zizmor` |
| --- | --- | --- |
| #145 clap | ok / ok | no findings |
| #146 cargo-deny-action | ok / ok | no findings |
| #147 tokio | ok / ok | no findings |
| #148 zizmor-action | ok / ok | no findings |
| #149 anyhow | ok / ok | no findings |
| #150 serde | ok / ok | no findings |
| #151 thiserror | ok / ok | no findings |
| #152 checkout digest | — | conflicts; superseded, see below |
| #153 libc | ok / ok | no findings |
| #154 serde_json | ok / ok | no findings |

For the `rust-toolchain` ignores, passing today proves nothing — today's pins match the branch tips. So the 07-17 failure was reconstructed by reverting the four pins to the stale SHAs and run both ways:

- with the ignores: `No findings to report. (3 ignored, 16 suppressed)`
- without them: `23 findings (16 suppressed): 4 medium, 3 high`

One honest note on that mechanism: with only `impostor-commit` listed, the four `ref-version-mismatch` findings also stop firing — appending the directive changes how the trailing comment parses, so that audit no longer evaluates rather than being explicitly ignored. `ref-version-mismatch` is kept in the list so that a future `zizmor` which parses the comment correctly still finds an explicit entry.

## Follow-ups

- **#152 should be closed, not merged.** It bumps `actions/checkout` to the same `3d3c42e` this PR uses (verified identical), but conflicts because this PR also rewrites the comment. Renovate is unlikely to auto-close it, since `# v7.0.1` reads as a different dependency version than the `v7` digest it was tracking.
- Until one of #145 / #150 / #151 lands, `cargo-deny` emits `warning[unnecessary-skip]: skip 'syn = =2' applied to a crate with only one version`. Exit code 0, non-blocking — expected, not a regression.
- The existing red checks on every Renovate PR stay red until each is rebased onto the fixed `main`.
